### PR TITLE
Fix physics semantics and training diagnostics

### DIFF
--- a/ascento/base.py
+++ b/ascento/base.py
@@ -170,7 +170,9 @@ class AscentoBaseEnv(mjx_env.MjxEnv):
         body_to_world = data.xmat[self._base_body_id]
         gravity = body_to_world.T @ jp.asarray([0.0, 0.0, -1.0])
         local_linear_velocity = body_to_world.T @ data.qvel[:3]
-        local_angular_velocity = body_to_world.T @ data.qvel[3:6]
+        # MuJoCo free-joint angular velocity is already expressed in the
+        # local body frame; only the translational velocity is world-frame.
+        local_angular_velocity = data.qvel[3:6]
         wheel_contact, wheel_force = observations.wheel_contacts_and_forces(data, self._wheel_body_ids)
         nonwheel_collision = observations.non_wheel_contact(data, self._non_wheel_body_ids)
         return gravity, local_linear_velocity, local_angular_velocity, wheel_contact, wheel_force, nonwheel_collision

--- a/ascento/jump.py
+++ b/ascento/jump.py
@@ -49,12 +49,15 @@ def update_jump_info(info: dict, data, wheel_contact, gravity, wheel_height):
     """Advances phase/event state using contacts, not a reference controller."""
     phase = info["jump_phase"]
     steps = info["phase_steps"] + 1
-    both_contact = jp.all(wheel_contact)
-    no_contact_steps = jp.where(both_contact, 0, info["no_contact_steps"] + 1)
-    landing_steps = jp.where(both_contact, info["landing_contact_steps"] + 1, 0)
+    all_contact = jp.all(wheel_contact)
+    any_contact = jp.any(wheel_contact)
+    # Flight requires both wheels to be clear.  A one-wheel lift must not
+    # count as airborne, while landing still requires both wheels down.
+    no_contact_steps = jp.where(any_contact, 0, info["no_contact_steps"] + 1)
+    landing_steps = jp.where(all_contact, info["landing_contact_steps"] + 1, 0)
     requested = info["command"][COMMAND_JUMP_TRIGGER] > 0.5
     upright = gravity[2] < -0.80
-    stable = upright & both_contact & (data.qpos[2] > 0.55) & (jp.linalg.norm(data.qvel[:6]) < 1.5)
+    stable = upright & all_contact & (data.qpos[2] > 0.55) & (jp.linalg.norm(data.qvel[:6]) < 1.5)
     recovery_steps = jp.where(stable, info["recovery_stable_steps"] + 1, 0)
 
     to_crouch = (phase == PHASE_IDLE) & requested

--- a/ascento/observations.py
+++ b/ascento/observations.py
@@ -36,7 +36,9 @@ def bounded_kinematics(data: mjx.Data, body_to_world: jax.Array):
     receive values large enough to saturate its policy network.
     """
     linear_velocity = jp.clip(body_to_world.T @ data.qvel[:3] / 5.0, -3.0, 3.0)
-    angular_velocity = jp.clip(body_to_world.T @ data.qvel[3:6] / 10.0, -3.0, 3.0)
+    # Free-joint rotational velocity is body-local in MuJoCo.  Applying the
+    # base rotation here would transform it a second time.
+    angular_velocity = jp.clip(data.qvel[3:6] / 10.0, -3.0, 3.0)
     joint_velocity = jp.clip(data.qvel[6:12] / 20.0, -3.0, 3.0)
     return linear_velocity, angular_velocity, joint_velocity
 

--- a/ascento/rewards.py
+++ b/ascento/rewards.py
@@ -16,6 +16,7 @@ from .constants import (
     PHASE_RECOVERY,
     PHASE_THRUST,
     STANCE,
+    LEG_INDEX,
 )
 
 
@@ -33,7 +34,9 @@ def base_terms(data, action, info, gravity, local_linear_velocity, local_angular
     # signal before the orientation termination boundary is reached.
     upright_gate = gravity[2] < -0.80
     recovered_gate = upright_gate & (jp.abs(data.qpos[2] - command[COMMAND_HEIGHT]) < 0.10)
-    posture = jp.exp(-0.25 * jp.sum(jp.square(data.qpos[7:13] - STANCE))) * upright_gate
+    leg_q = data.qpos[7:13][jp.asarray(LEG_INDEX)]
+    leg_stance = jp.asarray(STANCE)[jp.asarray(LEG_INDEX)]
+    posture = jp.exp(-0.25 * jp.sum(jp.square(leg_q - leg_stance))) * upright_gate
     stable = jp.exp(-0.10 * jp.sum(jp.square(data.qvel[:6]))) * recovered_gate
     action_rate = -0.015 * jp.sum(jp.square(action - info["last_action"]))
     action_smooth = -0.007 * jp.sum(

--- a/tests/test_physics_reward_correctness.py
+++ b/tests/test_physics_reward_correctness.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import jax.numpy as jp
+import numpy as np
+
+from ascento import jump
+from ascento.constants import PHASE_FLIGHT, PHASE_THRUST, STANCE
+from ascento.observations import bounded_kinematics
+from ascento.rewards import base_terms
+
+
+def test_angular_velocity_observation_preserves_body_local_free_joint_velocity():
+    # A 90-degree yaw makes an accidental world-to-body transform visible.
+    body_to_world = jp.asarray([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    data = SimpleNamespace(qvel=jp.asarray([0.0, 0.0, 0.0, 1.0, -2.0, 3.0] + [0.0] * 6))
+
+    _linear, angular, _joint = bounded_kinematics(data, body_to_world)
+
+    np.testing.assert_allclose(angular, jp.asarray([0.1, -0.2, 0.3]))
+
+
+def test_posture_reward_is_invariant_to_wheel_angle():
+    data = SimpleNamespace(
+        qpos=jp.asarray([0.0, 0.0, 0.75, 1.0, 0.0, 0.0, 0.0] + STANCE.tolist()),
+        qvel=jp.zeros(12),
+    )
+    info = {
+        "command": jp.asarray([0.0, 0.0, 0.75, 0.0, 0.0, 0.0]),
+        "last_action": jp.zeros(6),
+        "last_last_action": jp.zeros(6),
+        "last_torque": jp.zeros(6),
+    }
+    kwargs = dict(
+        action=jp.zeros(6),
+        info=info,
+        gravity=jp.asarray([0.0, 0.0, -1.0]),
+        local_linear_velocity=jp.zeros(3),
+        local_angular_velocity=jp.zeros(3),
+        nonwheel_collision=jp.asarray(False),
+    )
+    nominal = base_terms(data, **kwargs)
+    spun = data.qpos.at[9].set(123.0).at[12].set(-87.0)
+    rotated = base_terms(data.__class__(qpos=spun, qvel=data.qvel), **kwargs)
+
+    assert float(nominal["posture"]) == float(rotated["posture"])
+
+
+def test_one_wheel_lift_does_not_trigger_flight():
+    info = dict(jump.initial_jump_info(), command=jp.asarray([0.0, 0.0, 0.75, 1.0, 0.1, 0.0]))
+    gravity = jp.asarray([0.0, 0.0, -1.0])
+    data = SimpleNamespace(qpos=jp.asarray([0.0, 0.0, 0.82]), qvel=jp.asarray([0.0, 0.0, 1.0]))
+
+    info = jump.update_jump_info(info, data, jp.asarray([True, True]), gravity, jp.asarray([0.25, 0.25]))
+    for _ in range(16):
+        info = jump.update_jump_info(info, data, jp.asarray([True, True]), gravity, jp.asarray([0.25, 0.25]))
+    assert int(info["jump_phase"]) == PHASE_THRUST
+
+    for _ in range(3):
+        info = jump.update_jump_info(info, data, jp.asarray([True, False]), gravity, jp.asarray([0.32, 0.25]))
+    assert int(info["jump_phase"]) == PHASE_THRUST
+    assert float(info["jump_takeoff_event"]) == 0.0
+
+
+def test_two_wheel_no_contact_triggers_flight_after_hysteresis():
+    info = dict(jump.initial_jump_info(), command=jp.asarray([0.0, 0.0, 0.75, 1.0, 0.1, 0.0]))
+    gravity = jp.asarray([0.0, 0.0, -1.0])
+    contact = jp.asarray([True, True])
+    data = SimpleNamespace(qpos=jp.asarray([0.0, 0.0, 0.82]), qvel=jp.asarray([0.0, 0.0, 1.0]))
+
+    info = jump.update_jump_info(info, data, contact, gravity, jp.asarray([0.25, 0.25]))
+    for _ in range(16):
+        info = jump.update_jump_info(info, data, contact, gravity, jp.asarray([0.25, 0.25]))
+    assert int(info["jump_phase"]) == PHASE_THRUST
+
+    for _ in range(2):
+        info = jump.update_jump_info(info, data, jp.asarray([False, False]), gravity, jp.asarray([0.32, 0.32]))
+    assert int(info["jump_phase"]) == PHASE_FLIGHT

--- a/tests/test_ppo_network_factory.py
+++ b/tests/test_ppo_network_factory.py
@@ -1,0 +1,25 @@
+import jax
+import numpy as np
+import pytest
+
+from brax.training.acme import running_statistics
+
+from training.ppo_config import network_factory
+
+
+@pytest.mark.parametrize("hidden_sizes", [(16,), (16, 16), (16, 16, 16), (16, 16, 16, 16)])
+def test_network_factory_initializes_the_policy_output_for_any_depth(hidden_sizes):
+    action_size = 6
+    network = network_factory(hidden_sizes, initial_noise_std=0.10)(
+        10, action_size, running_statistics.normalize
+    )
+
+    params = network.policy_network.init(jax.random.PRNGKey(0))["params"]
+    output_key = f"hidden_{len(hidden_sizes)}"
+    output = params[output_key]
+
+    np.testing.assert_allclose(output["kernel"], 0.0)
+    np.testing.assert_allclose(output["bias"][:action_size], 0.0)
+    assert np.all(np.isfinite(np.asarray(output["bias"][action_size:])))
+    for index in range(len(hidden_sizes)):
+        assert np.any(np.asarray(params[f"hidden_{index}"]["kernel"]) != 0.0)

--- a/tests/test_render_training_progress.py
+++ b/tests/test_render_training_progress.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from tools.render_training_progress import tile_frames
+
+
+@pytest.mark.parametrize("frame_count", [1, 2, 3, 4, 5, 7, 11, 12])
+def test_tile_frames_pads_partial_final_rows(frame_count):
+    frames = [np.full((3, 5, 3), index, dtype=np.uint8) for index in range(frame_count)]
+
+    preview = tile_frames(frames)
+
+    expected_rows = (frame_count + 3) // 4
+    assert preview.shape == (expected_rows * 3, 4 * 5, 3)
+    for index, frame in enumerate(frames):
+        row, column = divmod(index, 4)
+        tile = preview[row * 3:(row + 1) * 3, column * 5:(column + 1) * 5]
+        np.testing.assert_array_equal(tile, frame)
+
+    if frame_count % 4:
+        last_row = preview[(expected_rows - 1) * 3:]
+        assert np.all(last_row[:, (frame_count % 4) * 5:] == 0)
+
+
+def test_tile_frames_rejects_empty_input():
+    with pytest.raises(ValueError, match="no frames"):
+        tile_frames([])

--- a/tools/render_training_progress.py
+++ b/tools/render_training_progress.py
@@ -53,6 +53,24 @@ def numeric_checkpoints(checkpoint_dir: Path):
     ) if checkpoint_dir.exists() else []
 
 
+def tile_frames(frames: list[np.ndarray], columns: int = 4) -> np.ndarray:
+    """Places rendered frames on a fixed-size canvas, including partial rows."""
+    if not frames:
+        raise ValueError("cannot build a preview grid with no frames")
+    if columns < 1:
+        raise ValueError("columns must be positive")
+
+    height, width, channels = frames[0].shape
+    if any(frame.shape != (height, width, channels) for frame in frames):
+        raise ValueError("all preview frames must have the same shape")
+    rows = (len(frames) + columns - 1) // columns
+    preview = np.zeros((rows * height, columns * width, channels), dtype=frames[0].dtype)
+    for index, frame in enumerate(frames):
+        row, column = divmod(index, columns)
+        preview[row * height:(row + 1) * height, column * width:(column + 1) * width] = frame
+    return preview
+
+
 def render_preview(env, policy, seed: int, output: Path, steps: int):
     """Writes a tiled PNG preview without spawning an ffmpeg subprocess."""
     reset, step = jax.jit(env.reset), jax.jit(env.step)
@@ -87,8 +105,7 @@ def render_preview(env, policy, seed: int, output: Path, steps: int):
                 break
     finally:
         renderer.close()
-    rows = [np.concatenate(frames[index:index + 4], axis=1) for index in range(0, len(frames), 4)]
-    preview = np.concatenate(rows, axis=0)
+    preview = tile_frames(frames)
     imageio.imwrite(output, preview)
     return {
         "seed": seed,

--- a/training/ppo_config.py
+++ b/training/ppo_config.py
@@ -58,14 +58,15 @@ def network_factory(hidden_sizes=(512, 256, 128), initial_noise_std: float = 0.1
         base_policy = ppo_network.policy_network
         requested_std = min(max(float(initial_noise_std), 0.0201), 0.1999)
         scale_logit = math.log((requested_std - 0.02) / (0.20 - requested_std))
+        final_key = f"hidden_{len(hidden_sizes)}"
 
         def init_policy(key):
             params = base_policy.init(key)
-            final = params["params"]["hidden_2"]
+            final = params["params"][final_key]
             bias = jp.zeros_like(final["bias"])
             bias = bias.at[action_size:].set(scale_logit)
             final = dict(final, kernel=jp.zeros_like(final["kernel"]), bias=bias)
-            return dict(params, params=dict(params["params"], hidden_2=final))
+            return dict(params, params=dict(params["params"], **{final_key: final}))
 
         ppo_network = ppo_network.replace(
             policy_network=replace(ppo_network.policy_network, init=init_policy)


### PR DESCRIPTION
## Summary
This follow-up PR finishes the outstanding fixes from the previous pass and addresses three high-yield physics issues:

- fix free-joint angular velocity handling in dynamics and observations (resolves #4)
- make posture reward depend only on hip/knee joints, not continuous wheel angles (resolves #7)
- require true zero-wheel-contact hysteresis before jump flight (resolves #8)
- keep progress-render preview grids valid for ragged/terminated rollouts (resolves #38)
- derive PPO policy-head initialization from configured network depth (resolves #39)

## Verification
- .................
17 passed in 19.26s — 17 passed
- 
- 

The active CUDA training process was not interrupted.