### PR TITLE
Add remote training web dashboard

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dashboard.txt -r requirements-dev.txt
-      - run: pytest -q tests/test_dashboard_monitor.py
+      - run: python -m pytest -q tests/test_dashboard_monitor.py
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -1,0 +1,40 @@
+name: Dashboard CI
+
+on:
+  pull_request:
+    paths:
+      - 'dashboard/**'
+      - 'tests/test_dashboard_monitor.py'
+      - 'requirements-dashboard.txt'
+      - '.github/workflows/dashboard-ci.yml'
+  push:
+    paths:
+      - 'dashboard/**'
+      - 'tests/test_dashboard_monitor.py'
+      - 'requirements-dashboard.txt'
+      - '.github/workflows/dashboard-ci.yml'
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-dashboard.txt -r requirements-dev.txt
+      - run: pytest -q tests/test_dashboard_monitor.py
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ __pycache__/
 .DS_Store
 MUJOCO_LOG.TXT
 
+# Dashboard frontend build/install output
+dashboard/frontend/node_modules/
+dashboard/frontend/dist/
+
 # Generated training and evaluation output
 training/artifacts*/
 training/runs/

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,94 @@
+# Ascento Training Dashboard
+
+A small local web dashboard for monitoring Brax/MJX training over Tailscale.
+It reads the artifacts the trainer already writes and does not own or supervise
+the PPO process itself.
+
+## What it shows
+
+- current stage, progress, steps/s, elapsed time and ETA from `telemetry.jsonl`;
+- automatically selected PPO/evaluation metric charts;
+- live captured console output using Server-Sent Events;
+- recent traceback/error excerpts;
+- the newest deterministic MuJoCo checkpoint preview and rollout statistics;
+- previous runs discovered under the artifact root.
+
+The web UI does not expose an arbitrary shell. Its only write action is a fixed
+"Render latest" endpoint that invokes the repository's deterministic checkpoint
+renderer for the selected run.
+
+## Install
+
+From the repository root, with the existing Python environment activated:
+
+```bash
+pip install -r requirements-dashboard.txt
+cd dashboard/frontend
+npm install
+npm run build
+cd ../..
+```
+
+For frontend development, run `npm run dev` in `dashboard/frontend`; Vite proxies
+`/api` requests to `127.0.0.1:8000`.
+
+## Start the dashboard
+
+```bash
+./scripts/run_dashboard.sh
+```
+
+The production server intentionally binds only to `127.0.0.1:8000`. To make it
+available to your tailnet without exposing it on the LAN:
+
+```bash
+tailscale serve --bg 8000
+```
+
+Open the HTTPS Tailscale Serve URL from another device on the same tailnet.
+Do not use Tailscale Funnel for this private monitor.
+
+Set a different artifact location when needed:
+
+```bash
+ASCENTO_ARTIFACT_ROOT=/path/to/runs ./scripts/run_dashboard.sh
+```
+
+## Start a monitored training run
+
+The normal trainer already writes `telemetry.jsonl` and checkpoints. To also
+capture console output and reliable process state, launch it through:
+
+```bash
+ASCENTO_JAX_PLATFORM=cuda python -m dashboard.launch -- \
+  --stage balance \
+  --timesteps 50000000 \
+  --num-envs 1024
+```
+
+This creates a unique directory such as:
+
+```text
+training/artifacts/20260902_110500_balance/
+├── checkpoint/
+├── telemetry.jsonl
+├── training.log
+├── run_status.json
+├── policy_params.pkl
+└── training_manifest.json
+```
+
+Any additional arguments after `--` are forwarded to `training.train`, except
+`--output`, which is managed by the launcher so runs cannot accidentally mix
+telemetry from different sessions.
+
+## Rendering checkpoints
+
+The dashboard can render the newest numeric checkpoint on demand. This runs a
+short deterministic MuJoCo rollout in a separate process and stores its PNG and
+`progress_renders.jsonl` under `<run>/renders/`.
+
+Rendering uses the same JAX backend environment as the dashboard process. On a
+GPU training machine it can therefore temporarily compete with PPO for GPU
+resources; use it as an occasional inspection tool rather than a live video
+stream.

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Ascento training dashboard package."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,198 @@
+"""FastAPI service for remotely monitoring Ascento PPO training."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from dashboard.monitor import (
+    list_run_summaries,
+    load_jsonl,
+    numeric_checkpoints,
+    resolve_run,
+    summarize_run,
+    tail_lines,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = Path(
+    os.environ.get("ASCENTO_ARTIFACT_ROOT", ROOT / "training" / "artifacts")
+).expanduser().resolve()
+FRONTEND_DIST = Path(
+    os.environ.get("ASCENTO_DASHBOARD_DIST", Path(__file__).parent / "frontend" / "dist")
+).expanduser().resolve()
+
+app = FastAPI(title="Ascento Training Monitor", version="1.0")
+_render_processes: dict[str, subprocess.Popen] = {}
+
+
+def _run(run_id: str):
+    try:
+        return resolve_run(ARTIFACT_ROOT, run_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="training run not found") from error
+
+
+@app.get("/api/health")
+def health():
+    return {"ok": True, "artifact_root": str(ARTIFACT_ROOT)}
+
+
+@app.get("/api/runs")
+def runs():
+    return {"runs": list_run_summaries(ARTIFACT_ROOT)}
+
+
+@app.get("/api/runs/{run_id}")
+def run_status(run_id: str):
+    ref = _run(run_id)
+    return summarize_run(ref.path, ARTIFACT_ROOT)
+
+
+@app.get("/api/runs/{run_id}/telemetry")
+def telemetry(run_id: str, limit: int = 2000):
+    ref = _run(run_id)
+    limit = max(1, min(limit, 20_000))
+    return {"records": load_jsonl(ref.path / "telemetry.jsonl", limit=limit)}
+
+
+@app.get("/api/runs/{run_id}/logs")
+def logs(run_id: str, tail: int = 500):
+    ref = _run(run_id)
+    tail = max(1, min(tail, 5000))
+    return {"lines": [line.rstrip("\n") for line in tail_lines(ref.path / "training.log", tail)]}
+
+
+@app.get("/api/runs/{run_id}/logs/stream")
+async def stream_logs(run_id: str, request: Request):
+    ref = _run(run_id)
+    log_path = ref.path / "training.log"
+
+    async def event_stream():
+        try:
+            position = log_path.stat().st_size
+        except OSError:
+            position = 0
+        inode = None
+        while True:
+            if await request.is_disconnected():
+                return
+            try:
+                stat = log_path.stat()
+                current_inode = getattr(stat, "st_ino", None)
+                if inode is not None and current_inode != inode:
+                    position = 0
+                inode = current_inode
+                if stat.st_size < position:
+                    position = 0
+                with log_path.open("r", encoding="utf-8", errors="replace") as handle:
+                    handle.seek(position)
+                    chunk = handle.read()
+                    position = handle.tell()
+                for line in chunk.splitlines():
+                    yield f"data: {json.dumps({'line': line})}\n\n"
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                yield f"event: monitor_error\ndata: {json.dumps({'message': str(error)})}\n\n"
+            yield ": keepalive\n\n"
+            await asyncio.sleep(1.0)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@app.get("/api/runs/{run_id}/render/latest")
+def render_image(run_id: str):
+    ref = _run(run_id)
+    summary = summarize_run(ref.path, ARTIFACT_ROOT)
+    render = summary.get("latest_render")
+    if not render:
+        raise HTTPException(status_code=404, detail="no rendered preview exists")
+    path = (ref.path / render["relative_path"]).resolve()
+    try:
+        path.relative_to(ref.path.resolve())
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail="invalid render path") from error
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="render file disappeared")
+    return FileResponse(path, media_type="image/png", filename=path.name)
+
+
+@app.post("/api/runs/{run_id}/render-latest", status_code=202)
+def render_latest(run_id: str):
+    ref = _run(run_id)
+    checkpoints = numeric_checkpoints(ref.path / "checkpoint")
+    if not checkpoints:
+        raise HTTPException(status_code=409, detail="this run has no numeric checkpoints")
+
+    existing = _render_processes.get(run_id)
+    if existing is not None and existing.poll() is None:
+        return {"state": "already_running", "pid": existing.pid}
+
+    summary = summarize_run(ref.path, ARTIFACT_ROOT)
+    output_dir = ref.path / "renders"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "dashboard.render_latest",
+        "--stage",
+        summary["stage"],
+        "--checkpoint-dir",
+        str(ref.path / "checkpoint"),
+        "--output-dir",
+        str(output_dir),
+    ]
+    log_handle = (output_dir / "render.log").open("a", encoding="utf-8")
+    process = subprocess.Popen(
+        command,
+        cwd=ROOT,
+        env=dict(os.environ),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    log_handle.close()
+    _render_processes[run_id] = process
+    return {"state": "started", "pid": process.pid, "checkpoint": checkpoints[-1].name}
+
+
+@app.get("/api/runs/{run_id}/render-status")
+def render_status(run_id: str):
+    _run(run_id)
+    process = _render_processes.get(run_id)
+    if process is None:
+        return {"state": "idle"}
+    code = process.poll()
+    if code is None:
+        return {"state": "running", "pid": process.pid}
+    return {"state": "finished" if code == 0 else "error", "exit_code": code}
+
+
+@app.get("/")
+def index():
+    index_path = FRONTEND_DIST / "index.html"
+    if index_path.is_file():
+        return FileResponse(index_path)
+    return JSONResponse(
+        {
+            "message": "Dashboard frontend is not built yet.",
+            "build": "cd dashboard/frontend && npm install && npm run build",
+            "api": "/api/runs",
+        }
+    )
+
+
+if (FRONTEND_DIST / "assets").is_dir():
+    app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0b1020" />
+    <title>Ascento Training Monitor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ascento-training-dashboard",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.15.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.1.0"
+  }
+}

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+const POLL_MS = 5000
+
+function fmtNumber(value, digits = 1) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—'
+  return Number(value).toLocaleString(undefined, { maximumFractionDigits: digits })
+}
+
+function fmtDuration(seconds) {
+  if (seconds === null || seconds === undefined || !Number.isFinite(Number(seconds))) return '—'
+  const total = Math.max(0, Math.round(Number(seconds)))
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  if (hours) return `${hours}h ${minutes}m`
+  if (minutes) return `${minutes}m ${secs}s`
+  return `${secs}s`
+}
+
+function StateBadge({ state }) {
+  return <span className={`state-badge state-${state || 'unknown'}`}>{state || 'unknown'}</span>
+}
+
+function MetricChart({ records, metric }) {
+  return (
+    <section className="panel metric-panel">
+      <div className="panel-title">{metric}</div>
+      <div className="chart-wrap">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={records} margin={{ top: 8, right: 14, left: -8, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="step" tickFormatter={(value) => `${fmtNumber(value / 1e6, 1)}M`} minTickGap={24} />
+            <YAxis width={58} tickFormatter={(value) => fmtNumber(value, 2)} domain={['auto', 'auto']} />
+            <Tooltip
+              formatter={(value) => fmtNumber(value, 5)}
+              labelFormatter={(step) => `${fmtNumber(step, 0)} steps`}
+            />
+            <Line type="monotone" dataKey={metric} dot={false} isAnimationActive={false} strokeWidth={2} connectNulls />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  )
+}
+
+function App() {
+  const [runs, setRuns] = useState([])
+  const [selectedId, setSelectedId] = useState(null)
+  const [detail, setDetail] = useState(null)
+  const [telemetry, setTelemetry] = useState([])
+  const [logs, setLogs] = useState([])
+  const [apiError, setApiError] = useState('')
+  const [renderState, setRenderState] = useState('idle')
+  const [autoScroll, setAutoScroll] = useState(true)
+  const terminalRef = useRef(null)
+
+  async function fetchJson(url, options) {
+    const response = await fetch(url, options)
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}))
+      throw new Error(body.detail || `${response.status} ${response.statusText}`)
+    }
+    return response.json()
+  }
+
+  async function refreshRuns() {
+    try {
+      const data = await fetchJson('/api/runs')
+      setRuns(data.runs || [])
+      setSelectedId((current) => current || data.runs?.[0]?.id || null)
+      setApiError('')
+    } catch (error) {
+      setApiError(error.message)
+    }
+  }
+
+  async function refreshSelected(id) {
+    if (!id) return
+    try {
+      const [run, points, render] = await Promise.all([
+        fetchJson(`/api/runs/${id}`),
+        fetchJson(`/api/runs/${id}/telemetry?limit=3000`),
+        fetchJson(`/api/runs/${id}/render-status`),
+      ])
+      setDetail(run)
+      setTelemetry(points.records || [])
+      setRenderState(render.state || 'idle')
+      setApiError('')
+    } catch (error) {
+      setApiError(error.message)
+    }
+  }
+
+  useEffect(() => {
+    refreshRuns()
+    const timer = setInterval(refreshRuns, POLL_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  useEffect(() => {
+    if (!selectedId) return undefined
+    refreshSelected(selectedId)
+    const timer = setInterval(() => refreshSelected(selectedId), POLL_MS)
+    return () => clearInterval(timer)
+  }, [selectedId])
+
+  useEffect(() => {
+    if (!selectedId) return undefined
+    let cancelled = false
+    setLogs([])
+    fetchJson(`/api/runs/${selectedId}/logs?tail=800`)
+      .then((data) => !cancelled && setLogs(data.lines || []))
+      .catch(() => {})
+    const source = new EventSource(`/api/runs/${selectedId}/logs/stream`)
+    source.onmessage = (event) => {
+      try {
+        const value = JSON.parse(event.data)
+        if (typeof value.line === 'string') {
+          setLogs((current) => [...current, value.line].slice(-1500))
+        }
+      } catch (_) {
+        // Ignore malformed log events; the stream will continue.
+      }
+    }
+    return () => {
+      cancelled = true
+      source.close()
+    }
+  }, [selectedId])
+
+  useEffect(() => {
+    if (autoScroll && terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight
+    }
+  }, [logs, autoScroll])
+
+  const chartRecords = useMemo(
+    () => telemetry.map((record) => ({ step: record.completed_steps, ...(record.metrics || {}) })),
+    [telemetry],
+  )
+
+  const metricKeys = useMemo(() => {
+    const keys = [...new Set(telemetry.flatMap((record) => Object.keys(record.metrics || {})))]
+    const preferred = keys.filter((key) => /reward|episode|loss|entropy|eval|surviv|fall/i.test(key))
+    return [...preferred, ...keys.filter((key) => !preferred.includes(key))].slice(0, 4)
+  }, [telemetry])
+
+  const progress = detail?.telemetry || {}
+  const percent = Number(progress.percent_complete || 0)
+
+  async function requestRender() {
+    if (!selectedId) return
+    setRenderState('starting')
+    try {
+      await fetchJson(`/api/runs/${selectedId}/render-latest`, { method: 'POST' })
+      setRenderState('running')
+      window.setTimeout(() => refreshSelected(selectedId), 1500)
+    } catch (error) {
+      setApiError(error.message)
+      setRenderState('error')
+    }
+  }
+
+  return (
+    <main className="app-shell">
+      <header className="topbar">
+        <div>
+          <div className="eyebrow">ASCENTO / MJX</div>
+          <h1>Training Monitor</h1>
+        </div>
+        <div className="topbar-actions">
+          {detail && <StateBadge state={detail.state} />}
+          <select value={selectedId || ''} onChange={(event) => setSelectedId(event.target.value)}>
+            {runs.map((run) => (
+              <option key={run.id} value={run.id}>{run.name}</option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      {apiError && <div className="api-error">{apiError}</div>}
+      {!detail && !apiError && <div className="empty-state">No training artifacts found yet.</div>}
+
+      {detail && (
+        <>
+          <section className="stats-grid">
+            <div className="stat-card"><span>Stage</span><strong>{detail.stage}</strong></div>
+            <div className="stat-card"><span>Progress</span><strong>{fmtNumber(percent, 2)}%</strong></div>
+            <div className="stat-card"><span>Steps</span><strong>{fmtNumber(progress.completed_steps, 0)}</strong><small>/ {fmtNumber(progress.total_steps, 0)}</small></div>
+            <div className="stat-card"><span>Throughput</span><strong>{fmtNumber(progress.steps_per_second, 0)}</strong><small>steps/s</small></div>
+            <div className="stat-card"><span>Elapsed</span><strong>{fmtDuration(progress.elapsed_seconds)}</strong></div>
+            <div className="stat-card"><span>ETA</span><strong>{fmtDuration(progress.eta_seconds)}</strong></div>
+          </section>
+
+          <section className="panel progress-panel">
+            <div className="progress-heading"><span>Training progress</span><span>{fmtNumber(percent, 2)}%</span></div>
+            <div className="progress-track"><div className="progress-fill" style={{ width: `${Math.min(100, Math.max(0, percent))}%` }} /></div>
+          </section>
+
+          <section className="content-grid">
+            <div className="charts-grid">
+              {metricKeys.length ? metricKeys.map((metric) => (
+                <MetricChart key={metric} records={chartRecords} metric={metric} />
+              )) : <section className="panel empty-panel">Waiting for metric telemetry…</section>}
+            </div>
+
+            <aside className="side-column">
+              <section className="panel render-panel">
+                <div className="panel-title-row">
+                  <div className="panel-title">Latest rollout</div>
+                  <button onClick={requestRender} disabled={!detail.has_checkpoint || renderState === 'running' || renderState === 'starting'}>
+                    {renderState === 'running' || renderState === 'starting' ? 'Rendering…' : 'Render latest'}
+                  </button>
+                </div>
+                {detail.latest_render ? (
+                  <>
+                    <img src={`/api/runs/${detail.id}/render/latest?t=${detail.modified_at}`} alt="Latest deterministic MuJoCo rollout preview" />
+                    <div className="render-meta">
+                      {['step', 'return', 'survival_steps', 'min_height', 'max_abs_qvel', 'action_saturation_fraction'].map((key) => (
+                        detail.latest_render[key] !== undefined && <div key={key}><span>{key}</span><strong>{fmtNumber(detail.latest_render[key], 3)}</strong></div>
+                      ))}
+                    </div>
+                  </>
+                ) : <div className="empty-panel">No preview rendered yet.</div>}
+              </section>
+
+              <section className={`panel error-panel ${detail.errors?.length ? 'has-errors' : ''}`}>
+                <div className="panel-title">Errors</div>
+                {detail.errors?.length ? <pre>{detail.errors.join('\n')}</pre> : <div className="ok-message">No recent errors detected.</div>}
+              </section>
+            </aside>
+          </section>
+
+          <section className="panel terminal-panel">
+            <div className="panel-title-row">
+              <div className="panel-title">Console output</div>
+              <label className="checkbox"><input type="checkbox" checked={autoScroll} onChange={(event) => setAutoScroll(event.target.checked)} /> auto-scroll</label>
+            </div>
+            <pre ref={terminalRef} className="terminal">{logs.length ? logs.join('\n') : 'No captured training.log for this run.'}</pre>
+          </section>
+        </>
+      )}
+    </main>
+  )
+}
+
+export default App

--- a/dashboard/frontend/src/main.jsx
+++ b/dashboard/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/dashboard/frontend/src/styles.css
+++ b/dashboard/frontend/src/styles.css
@@ -1,0 +1,86 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e8edf7;
+  background: #080b12;
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: radial-gradient(circle at top, #121a2c 0, #080b12 42%); }
+button, select, input { font: inherit; }
+button { cursor: pointer; }
+
+.app-shell { width: min(1500px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+.topbar { display: flex; justify-content: space-between; gap: 24px; align-items: center; margin-bottom: 24px; }
+.eyebrow { color: #86a8ff; letter-spacing: .16em; font-size: .72rem; font-weight: 800; }
+h1 { margin: 5px 0 0; font-size: clamp(1.7rem, 3vw, 2.5rem); }
+.topbar-actions { display: flex; align-items: center; gap: 12px; }
+select, button { border: 1px solid #2b3853; border-radius: 10px; background: #121827; color: #e8edf7; padding: 9px 12px; }
+button:hover:not(:disabled), select:hover { border-color: #5d7bbb; }
+button:disabled { opacity: .5; cursor: default; }
+
+.state-badge { border-radius: 999px; padding: 6px 10px; text-transform: uppercase; font-size: .72rem; font-weight: 800; letter-spacing: .08em; border: 1px solid currentColor; }
+.state-running { color: #62d995; }
+.state-finished { color: #7bb7ff; }
+.state-error, .state-cancelled { color: #ff7d8f; }
+.state-starting, .state-unknown { color: #d0ae68; }
+
+.api-error { border: 1px solid #7d3441; background: #251117; color: #ffb8c1; padding: 12px 14px; border-radius: 12px; margin-bottom: 16px; }
+.empty-state { padding: 60px 20px; text-align: center; color: #8895aa; }
+
+.stats-grid { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 12px; margin-bottom: 12px; }
+.stat-card, .panel { border: 1px solid #202a3d; background: rgba(15, 21, 34, .92); border-radius: 14px; box-shadow: 0 12px 35px rgba(0,0,0,.16); }
+.stat-card { padding: 16px; min-width: 0; }
+.stat-card span, .stat-card small { display: block; color: #8390a5; font-size: .75rem; }
+.stat-card strong { display: block; margin-top: 6px; font-size: 1.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.stat-card small { margin-top: 3px; }
+
+.panel { padding: 16px; }
+.panel-title { font-size: .82rem; color: #aab5c7; font-weight: 700; overflow-wrap: anywhere; }
+.panel-title-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.progress-panel { margin-bottom: 12px; }
+.progress-heading { display: flex; justify-content: space-between; color: #aab5c7; margin-bottom: 10px; font-size: .82rem; }
+.progress-track { height: 10px; border-radius: 999px; background: #20293a; overflow: hidden; }
+.progress-fill { height: 100%; border-radius: inherit; background: linear-gradient(90deg, #7096ff, #77dfbf); transition: width .35s ease; }
+
+.content-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, .85fr); gap: 12px; }
+.charts-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.metric-panel { min-height: 280px; }
+.chart-wrap { height: 230px; margin-top: 10px; }
+.recharts-cartesian-grid line { stroke: #283246; }
+.recharts-text { fill: #7f8ca1; font-size: 11px; }
+.recharts-default-tooltip { background: #0c111d !important; border: 1px solid #33405a !important; border-radius: 8px; }
+
+.side-column { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.render-panel img { width: 100%; display: block; border-radius: 10px; border: 1px solid #252f43; background: #05070a; }
+.render-meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+.render-meta div { background: #0c111c; padding: 8px 9px; border-radius: 8px; min-width: 0; }
+.render-meta span, .render-meta strong { display: block; overflow: hidden; text-overflow: ellipsis; }
+.render-meta span { color: #738198; font-size: .68rem; }
+.render-meta strong { font-size: .85rem; margin-top: 3px; }
+.error-panel { flex: 1; }
+.error-panel.has-errors { border-color: #70323c; }
+.error-panel pre { max-height: 250px; overflow: auto; white-space: pre-wrap; color: #ffabb5; font-size: .75rem; }
+.ok-message, .empty-panel { color: #7f8ca1; padding: 18px 0; }
+
+.terminal-panel { margin-top: 12px; }
+.checkbox { color: #8d9ab0; font-size: .78rem; display: flex; gap: 6px; align-items: center; }
+.terminal { margin: 0; height: 330px; overflow: auto; background: #05070b; border: 1px solid #202a3a; border-radius: 10px; padding: 14px; color: #c6d2e6; font: 12px/1.55 "Cascadia Code", "SFMono-Regular", Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+
+@media (max-width: 1050px) {
+  .stats-grid { grid-template-columns: repeat(3, 1fr); }
+  .content-grid { grid-template-columns: 1fr; }
+  .side-column { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 700px) {
+  .app-shell { width: min(100% - 20px, 1500px); padding-top: 18px; }
+  .topbar { align-items: flex-start; flex-direction: column; }
+  .topbar-actions { width: 100%; }
+  .topbar-actions select { flex: 1; min-width: 0; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .charts-grid, .side-column { grid-template-columns: 1fr; }
+  .metric-panel { min-height: 250px; }
+  .chart-wrap { height: 205px; }
+  .terminal { height: 420px; }
+}

--- a/dashboard/frontend/vite.config.js
+++ b/dashboard/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:8000',
+    },
+  },
+})

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -1,0 +1,104 @@
+"""Launch training with durable console logging and run lifecycle metadata."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def write_status(path: Path, **values) -> None:
+    current = {}
+    if path.exists():
+        try:
+            current = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            current = {}
+    current.update(values)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(current, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run training.train while capturing console output for the web dashboard."
+    )
+    parser.add_argument("--artifact-root", type=Path, default=Path("training/artifacts"))
+    parser.add_argument("--name", help="run directory name; defaults to timestamp_stage")
+    parser.add_argument("training_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    training_args = list(args.training_args)
+    if training_args and training_args[0] == "--":
+        training_args = training_args[1:]
+    if "--output" in training_args:
+        parser.error("do not pass --output; dashboard.launch assigns an isolated run directory")
+
+    stage = "balance"
+    if "--stage" in training_args:
+        index = training_args.index("--stage")
+        if index + 1 < len(training_args):
+            stage = training_args[index + 1]
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_name = args.name or f"{stamp}_{stage}"
+    run_dir = (args.artifact_root / run_name).resolve()
+    if run_dir.exists() and any(run_dir.iterdir()):
+        parser.error(f"run directory already exists and is not empty: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    status_path = run_dir / "run_status.json"
+    log_path = run_dir / "training.log"
+    command = [
+        sys.executable,
+        "-u",
+        "-m",
+        "training.train",
+        *training_args,
+        "--output",
+        str(run_dir),
+    ]
+    started = datetime.now(timezone.utc).isoformat()
+    write_status(
+        status_path,
+        state="starting",
+        stage=stage,
+        started_at=started,
+        command=command,
+        exit_code=None,
+    )
+
+    with log_path.open("a", encoding="utf-8", buffering=1) as log:
+        log.write("DASHBOARD_LAUNCH " + " ".join(command) + "\n")
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        write_status(status_path, state="running", pid=process.pid)
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                log.write(line)
+            exit_code = process.wait()
+        except KeyboardInterrupt:
+            process.terminate()
+            exit_code = process.wait()
+            write_status(status_path, state="cancelled", exit_code=exit_code)
+            raise
+
+    finished = datetime.now(timezone.utc).isoformat()
+    state = "finished" if exit_code == 0 else "error"
+    write_status(status_path, state=state, exit_code=exit_code, finished_at=finished)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/monitor.py
+++ b/dashboard/monitor.py
@@ -1,0 +1,209 @@
+"""Filesystem-backed monitoring helpers for Ascento training runs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha1
+import json
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any, Iterable
+
+
+ERROR_PATTERN = re.compile(
+    r"(traceback|\berror\b|exception|floatingpointerror|non-finite|cuda.*fail|out of memory|oom)",
+    re.IGNORECASE,
+)
+RUN_MARKERS = (
+    "telemetry.jsonl",
+    "training.log",
+    "run_status.json",
+    "training_manifest.json",
+)
+
+
+@dataclass(frozen=True)
+class RunRef:
+    id: str
+    path: Path
+    relative_path: str
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(value, dict):
+                    records.append(value)
+    except OSError:
+        return []
+    return records[-limit:] if limit is not None else records
+
+
+def tail_lines(path: Path, count: int = 400) -> list[str]:
+    if count <= 0 or not path.is_file():
+        return []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            return handle.readlines()[-count:]
+    except OSError:
+        return []
+
+
+def error_excerpt(path: Path, max_lines: int = 80) -> list[str]:
+    lines = tail_lines(path, 1200)
+    if not lines:
+        return []
+    selected: set[int] = set()
+    for index, line in enumerate(lines):
+        if ERROR_PATTERN.search(line):
+            selected.update(range(max(0, index - 2), min(len(lines), index + 4)))
+    ordered = [lines[index].rstrip("\n") for index in sorted(selected)]
+    return ordered[-max_lines:]
+
+
+def discover_runs(root: Path) -> list[RunRef]:
+    root = root.expanduser().resolve()
+    if not root.exists():
+        return []
+    candidates: set[Path] = set()
+    if any((root / marker).exists() for marker in RUN_MARKERS):
+        candidates.add(root)
+    for marker in RUN_MARKERS:
+        for path in root.rglob(marker):
+            candidates.add(path.parent.resolve())
+    refs = []
+    for path in candidates:
+        if not _inside(path, root):
+            continue
+        relative = "." if path == root else path.relative_to(root).as_posix()
+        refs.append(RunRef(sha1(relative.encode("utf-8")).hexdigest()[:12], path, relative))
+    return sorted(refs, key=lambda ref: run_modified_time(ref.path), reverse=True)
+
+
+def resolve_run(root: Path, run_id: str) -> RunRef:
+    for ref in discover_runs(root):
+        if ref.id == run_id:
+            return ref
+    raise KeyError(run_id)
+
+
+def run_modified_time(run_dir: Path) -> float:
+    mtimes = []
+    for marker in RUN_MARKERS:
+        path = run_dir / marker
+        try:
+            mtimes.append(path.stat().st_mtime)
+        except OSError:
+            pass
+    return max(mtimes, default=run_dir.stat().st_mtime if run_dir.exists() else 0.0)
+
+
+def _stage_name(run_dir: Path, telemetry: dict[str, Any] | None, manifest: dict[str, Any] | None) -> str:
+    if telemetry and telemetry.get("stage"):
+        return str(telemetry["stage"])
+    if manifest:
+        stage = manifest.get("stage")
+        if isinstance(stage, dict) and stage.get("name"):
+            return str(stage["name"])
+        if isinstance(stage, str):
+            return stage
+    return run_dir.name
+
+
+def latest_render(run_dir: Path) -> dict[str, Any] | None:
+    manifest_candidates = [
+        run_dir / "renders" / "progress_renders.jsonl",
+        run_dir / "progress_renders.jsonl",
+    ]
+    for manifest_path in manifest_candidates:
+        records = load_jsonl(manifest_path, limit=1)
+        if not records:
+            continue
+        record = records[-1]
+        raw_path = record.get("path")
+        if raw_path:
+            path = Path(str(raw_path))
+            if not path.is_file():
+                path = manifest_path.parent / path.name
+            if path.is_file() and _inside(path, run_dir):
+                return {**record, "filename": path.name, "relative_path": path.relative_to(run_dir).as_posix()}
+    pngs = list((run_dir / "renders").glob("*.png")) if (run_dir / "renders").exists() else []
+    if not pngs:
+        pngs = list(run_dir.glob("*.png"))
+    if not pngs:
+        return None
+    path = max(pngs, key=lambda item: item.stat().st_mtime)
+    return {"filename": path.name, "relative_path": path.relative_to(run_dir).as_posix()}
+
+
+def summarize_run(run_dir: Path, root: Path, now: float | None = None) -> dict[str, Any]:
+    now = time.time() if now is None else now
+    telemetry_records = load_jsonl(run_dir / "telemetry.jsonl", limit=1)
+    telemetry = telemetry_records[-1] if telemetry_records else None
+    manifest = load_json(run_dir / "training_manifest.json")
+    status = load_json(run_dir / "run_status.json") or {}
+    errors = error_excerpt(run_dir / "training.log")
+
+    state = status.get("state")
+    if not state:
+        if manifest:
+            state = "finished"
+        elif errors and now - run_modified_time(run_dir) > 30:
+            state = "error"
+        elif telemetry:
+            state = "running" if now - run_modified_time(run_dir) < 600 else "unknown"
+        else:
+            state = "unknown"
+
+    relative = "." if run_dir.resolve() == root.resolve() else run_dir.resolve().relative_to(root.resolve()).as_posix()
+    return {
+        "id": sha1(relative.encode("utf-8")).hexdigest()[:12],
+        "name": relative,
+        "stage": _stage_name(run_dir, telemetry, manifest),
+        "state": state,
+        "modified_at": run_modified_time(run_dir),
+        "status": status,
+        "telemetry": telemetry,
+        "errors": errors,
+        "latest_render": latest_render(run_dir),
+        "has_log": (run_dir / "training.log").is_file(),
+        "has_checkpoint": (run_dir / "checkpoint").is_dir(),
+    }
+
+
+def list_run_summaries(root: Path) -> list[dict[str, Any]]:
+    return [summarize_run(ref.path, root) for ref in discover_runs(root)]
+
+
+def numeric_checkpoints(checkpoint_dir: Path) -> list[Path]:
+    if not checkpoint_dir.is_dir():
+        return []
+    return sorted(
+        (path for path in checkpoint_dir.iterdir() if path.is_dir() and path.name.isdigit()),
+        key=lambda path: int(path.name),
+    )

--- a/dashboard/render_latest.py
+++ b/dashboard/render_latest.py
@@ -1,0 +1,54 @@
+"""Render exactly one preview from the newest available PPO checkpoint."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+from training.ppo_config import build_environment
+from tools.render_training_progress import (
+    load_checkpoint_policy,
+    numeric_checkpoints,
+    render_preview,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", default="balance")
+    parser.add_argument("--checkpoint-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--steps", type=int, default=240)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--hidden-sizes", default="128,128")
+    parser.add_argument("--initial-noise-std", type=float)
+    args = parser.parse_args()
+
+    checkpoints = numeric_checkpoints(args.checkpoint_dir)
+    if not checkpoints:
+        parser.error(f"no numeric checkpoints in {args.checkpoint_dir}")
+    checkpoint_path = checkpoints[-1]
+    hidden_sizes = tuple(int(value) for value in args.hidden_sizes.split(",") if value)
+    env, stage = build_environment(args.stage, episode_length=args.steps)
+    initial_noise_std = args.initial_noise_std or stage.initial_noise_std
+    policy = load_checkpoint_policy(checkpoint_path, env, hidden_sizes, initial_noise_std)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output = args.output_dir / f"{args.stage}_step_{int(checkpoint_path.name):09d}.png"
+    report = render_preview(env, policy, args.seed, output, args.steps)
+    record = {
+        "checkpoint": str(checkpoint_path.resolve()),
+        "step": int(checkpoint_path.name),
+        **report,
+    }
+    with (args.output_dir / "progress_renders.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+    print("PROGRESS_RENDER " + json.dumps(record), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,0 +1,3 @@
+# Lightweight web monitor; install alongside the simulation environment.
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30,<1

--- a/scripts/run_dashboard.sh
+++ b/scripts/run_dashboard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST="$ROOT/dashboard/frontend/dist"
+
+if [[ ! -f "$DIST/index.html" ]]; then
+  echo "Dashboard frontend is not built." >&2
+  echo "Run: cd dashboard/frontend && npm install && npm run build" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+exec python -m uvicorn dashboard.app:app --host 127.0.0.1 --port "${ASCENTO_DASHBOARD_PORT:-8000}"

--- a/tests/test_dashboard_monitor.py
+++ b/tests/test_dashboard_monitor.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+
+from dashboard.monitor import discover_runs, error_excerpt, load_jsonl, summarize_run
+
+
+def write_jsonl(path: Path, records):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+
+
+def test_discover_and_summarize_run(tmp_path):
+    run = tmp_path / "20260902_balance"
+    write_jsonl(
+        run / "telemetry.jsonl",
+        [
+            {
+                "stage": "balance",
+                "completed_steps": 250,
+                "total_steps": 1000,
+                "percent_complete": 25.0,
+                "steps_per_second": 100.0,
+                "eta_seconds": 7.5,
+                "metrics": {"eval/episode_reward": 3.0},
+            }
+        ],
+    )
+
+    refs = discover_runs(tmp_path)
+    assert len(refs) == 1
+    summary = summarize_run(run, tmp_path, now=(run / "telemetry.jsonl").stat().st_mtime + 1)
+    assert summary["stage"] == "balance"
+    assert summary["state"] == "running"
+    assert summary["telemetry"]["percent_complete"] == 25.0
+
+
+def test_manifest_marks_run_finished(tmp_path):
+    run = tmp_path / "finished"
+    run.mkdir()
+    (run / "training_manifest.json").write_text(
+        json.dumps({"stage": {"name": "recovery"}}), encoding="utf-8"
+    )
+    summary = summarize_run(run, tmp_path)
+    assert summary["state"] == "finished"
+    assert summary["stage"] == "recovery"
+
+
+def test_explicit_error_status_wins(tmp_path):
+    run = tmp_path / "failed"
+    run.mkdir()
+    (run / "run_status.json").write_text(
+        json.dumps({"state": "error", "exit_code": 1}), encoding="utf-8"
+    )
+    summary = summarize_run(run, tmp_path)
+    assert summary["state"] == "error"
+    assert summary["status"]["exit_code"] == 1
+
+
+def test_jsonl_skips_partial_or_corrupt_lines(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    path.write_text('{"step": 1}\nnot-json\n{"step": 2', encoding="utf-8")
+    assert load_jsonl(path) == [{"step": 1}]
+
+
+def test_error_excerpt_keeps_context(tmp_path):
+    log = tmp_path / "training.log"
+    log.write_text(
+        "normal line\n"
+        "before failure\n"
+        "Traceback (most recent call last):\n"
+        "  File train.py, line 10\n"
+        "FloatingPointError: Non-finite PPO metrics detected\n",
+        encoding="utf-8",
+    )
+    excerpt = error_excerpt(log)
+    assert any("Traceback" in line for line in excerpt)
+    assert any("Non-finite" in line for line in excerpt)
+
+
+def test_latest_render_is_confined_to_run(tmp_path):
+    run = tmp_path / "rendered"
+    renders = run / "renders"
+    renders.mkdir(parents=True)
+    image = renders / "balance_step_000000100.png"
+    image.write_bytes(b"png")
+    write_jsonl(
+        renders / "progress_renders.jsonl",
+        [{"step": 100, "path": str(image), "return": 4.2}],
+    )
+    summary = summarize_run(run, tmp_path)
+    assert summary["latest_render"]["step"] == 100
+    assert summary["latest_render"]["relative_path"].startswith("renders/")


### PR DESCRIPTION
## Summary

Adds a Tailscale-friendly web dashboard for monitoring Ascento Brax/MJX training.

### Backend
- FastAPI API over the existing training artifact format
- run discovery under `training/artifacts`
- progress/status from `telemetry.jsonl` and `training_manifest.json`
- live console streaming over Server-Sent Events
- recent traceback/error extraction
- latest rollout image + rollout metrics
- controlled one-shot rendering of the newest checkpoint (no arbitrary shell endpoint)

### Frontend
- React + Vite
- Recharts metric plots
- responsive progress/status cards
- run selector
- latest MuJoCo preview panel
- live terminal with auto-scroll
- dedicated error panel

### Training integration
- `python -m dashboard.launch -- ...` creates an isolated run directory, captures stdout/stderr to `training.log`, and writes `run_status.json`
- existing runs remain readable without using the launcher

### Remote access
- production server binds to `127.0.0.1`
- documented `tailscale serve --bg 8000` setup

## Validation

Added `.github/workflows/dashboard-ci.yml` so the dashboard is validated in a clean checkout.

Latest CI result on commit `0240294f1b804847093ca03063fda7553dd21621`:
- backend: `python -m pytest -q tests/test_dashboard_monitor.py` — **passed**
- frontend: `npm install && npm run build` — **passed**

An initial CI run exposed an import-path issue with invoking `pytest` directly; the workflow now uses `python -m pytest`, matching a clean repository-root execution and passing successfully.

The registered `Marcus_Computer` device responds to connectivity pings, but its Remote Desktop Commander shell/process channel is currently returning `Not connected`; therefore the successful clean-checkout CI run is the executable validation for this revision.
