### PR TITLE
Address reproducibility and motion-authoring issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Use Linux/WSL2, Python 3.11–3.13, an NVIDIA driver compatible with the pinned
 CUDA wheel, and `uv`:
 
 ```bash
-uv sync --extra cu128
+uv sync --extra cu128 --extra dashboard
 ```
 
 For CPU-only development:
 
 ```bash
-uv sync --extra cpu
+uv sync --extra cpu --extra dashboard
 ```
 
 The lockfile pins mjlab 1.6.0, MuJoCo 3.11, MuJoCo Warp, Warp, Torch, and
@@ -92,8 +92,23 @@ uv run --extra cu128 python -m ascento_mjlab.tools.capture_motion \
 ```
 
 Omit `--checkpoint` for a zero-action plant capture. Each take includes time,
-root transforms, joint state, applied effort, action, task, seed, and capture
-FPS.
+root transforms, local joint state, contact state, jump state when available,
+applied effort, action, task, seed, checkpoint hash, physics profile, and
+capture FPS. Trim and resample a take for animation use:
+
+```bash
+uv run clip-motion captures/jump/take_000.npz \
+  --event takeoff --pre-roll 0.5 --post-roll 1.0 --fps 24 \
+  --output captures/jump/jump_short.npz
+```
+
+Rank a batch of captures by smoothness and contact quality. This quality score
+is separate from task-success acceptance and is intended to select candidates
+for visual review:
+
+```bash
+uv run rank-motion captures/jump --top 5 --output captures/jump/ranking.json
+```
 
 ## Docker
 
@@ -122,7 +137,7 @@ specific important plant regression.
 - `src/ascento_mjlab/actuator.py`: peak/speed/response actuator extension.
 - `src/ascento_mjlab/mdp/`: Ascento observations, rewards, resets, semantics, metrics.
 - `src/ascento_mjlab/tasks/`: balance, velocity, recovery, and flat-jump configs.
-- `src/ascento_mjlab/tools/`: smoke, model inspection, plant comparison, capture.
+- `src/ascento_mjlab/tools/`: smoke, model inspection, plant comparison, capture, clip processing, and motion-quality ranking.
 - `tests_mjlab/`: migration unit and integration tests.
 
 The old JAX/MJX/Brax implementation remains available only in Git history and

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,7 +5,7 @@ It reads run artifacts and does not own or supervise the PPO process itself.
 
 ## What it shows
 
-- current stage, progress, steps/s, elapsed time and ETA from `telemetry.jsonl`;
+- current stage, progress, steps/s, elapsed time and ETA from RSL-RL TensorBoard events;
 - TensorBoard/RSL-RL metric artifacts and console output;
 - live captured console output using Server-Sent Events;
 - recent traceback/error excerpts;
@@ -20,7 +20,7 @@ does not compete with training or become a second rollout framework.
 From the repository root, after installing the project with uv:
 
 ```bash
-uv sync --extra cu128
+uv sync --extra cu128 --extra dashboard
 cd dashboard/frontend
 npm install
 npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /workspace
 COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 COPY tests_mjlab ./tests_mjlab
-RUN uv sync --frozen --extra cu128 --no-dev
+RUN uv sync --frozen --extra cu128 --extra dashboard --no-dev
 
 COPY docker/smoke.sh /usr/local/bin/ascento-smoke
 RUN chmod +x /usr/local/bin/ascento-smoke && mkdir -p /workspace/logs /workspace/checkpoints /workspace/captures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,11 @@ dependencies = [
 [project.optional-dependencies]
 cu128 = ["torch>=2.7.0"]
 cpu = ["torch>=2.7.0"]
-dashboard = ["fastapi>=0.115.0", "uvicorn[standard]>=0.34.0"]
+dashboard = ["fastapi==0.141.1", "uvicorn[standard]==0.52.4"]
+
+[project.scripts]
+clip-motion = "ascento_mjlab.tools.clip_motion:main"
+rank-motion = "ascento_mjlab.tools.motion_quality:main"
 
 [dependency-groups]
 dev = [

--- a/src/ascento_mjlab/tools/capture_motion.py
+++ b/src/ascento_mjlab/tools/capture_motion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 from dataclasses import asdict
 from pathlib import Path
 
@@ -27,17 +28,40 @@ class MotionRecorder(RecorderTerm):
   def record_post_step(self) -> None:
     env = self._env
     robot = env.scene["robot"]
-    self.frames.append(
-      {
-        "time": env.common_step_counter * env.step_dt,
-        "root_pos": robot.data.root_link_pos_w[0].detach().cpu().numpy().copy(),
-        "root_quat": robot.data.root_link_quat_w[0].detach().cpu().numpy().copy(),
-        "joint_pos": robot.data.joint_pos[0].detach().cpu().numpy().copy(),
-        "joint_vel": robot.data.joint_vel[0].detach().cpu().numpy().copy(),
-        "effort": robot.data.actuator_force[0].detach().cpu().numpy().copy(),
-        "action": env.action_manager.action[0].detach().cpu().numpy().copy(),
-      }
-    )
+    frame = {
+      "time": env.common_step_counter * env.step_dt,
+      "root_pos": robot.data.root_link_pos_w[0].detach().cpu().numpy().copy(),
+      "root_quat": robot.data.root_link_quat_w[0].detach().cpu().numpy().copy(),
+      "joint_pos": robot.data.joint_pos[0].detach().cpu().numpy().copy(),
+      "joint_vel": robot.data.joint_vel[0].detach().cpu().numpy().copy(),
+      "effort": robot.data.actuator_force[0].detach().cpu().numpy().copy(),
+      "action": env.action_manager.action[0].detach().cpu().numpy().copy(),
+    }
+    contacts = []
+    for sensor_name in ("left_wheel_contact", "right_wheel_contact"):
+      try:
+        sensor = env.scene[sensor_name]
+      except KeyError:
+        sensor = None
+      if sensor is not None and sensor.data.found is not None:
+        contacts.append(float(sensor.data.found[0].flatten().any()))
+    if len(contacts) == 2:
+      frame["contacts"] = np.asarray(contacts, dtype=np.float32)
+    if hasattr(env, "ascento_jump_state"):
+      state = env.ascento_jump_state
+      frame["jump_state"] = np.asarray(
+        [state["airborne"][0], state["takeoff"][0], state["landing"][0], state["air_time"][0]],
+        dtype=np.float32,
+      )
+    for command_name in ("motion", "twist"):
+      try:
+        command = env.command_manager.get_command(command_name)
+      except (AttributeError, KeyError):
+        command = None
+      if command is not None:
+        frame["command"] = command[0].detach().cpu().numpy().copy()
+        break
+    self.frames.append(frame)
 
   def export(self, path: Path, *, metadata: dict[str, str]) -> None:
     if not self.frames:
@@ -63,6 +87,10 @@ def main() -> None:
     parser.error("--takes and --steps must be positive")
   if args.checkpoint is not None and not args.checkpoint.is_file():
     parser.error(f"checkpoint does not exist: {args.checkpoint}")
+
+  checkpoint_hash = ""
+  if args.checkpoint is not None:
+    checkpoint_hash = hashlib.sha256(args.checkpoint.read_bytes()).hexdigest()
 
   for take in range(args.takes):
     cfg = load_env_cfg(args.task, play=True)
@@ -108,7 +136,14 @@ def main() -> None:
     recorder = raw_env.recorder_manager.get_term("motion")
     recorder.export(
       args.output_dir / f"take_{take:03d}.npz",
-      metadata={"task": args.task, "seed": str(take), "fps": str(round(1.0 / raw_env.step_dt))},
+      metadata={
+        "task": args.task,
+        "seed": str(take),
+        "fps": str(round(1.0 / raw_env.step_dt)),
+        "checkpoint": str(args.checkpoint) if args.checkpoint is not None else "",
+        "model_sha256": checkpoint_hash,
+        "physics_profile": "animation_high_authority",
+      },
     )
     env.close()
 

--- a/src/ascento_mjlab/tools/clip_motion.py
+++ b/src/ascento_mjlab/tools/clip_motion.py
@@ -1,0 +1,200 @@
+"""Trim and resample RecorderManager motion captures for animation use."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def load_capture(path: Path) -> dict[str, np.ndarray]:
+  """Load a capture without enabling pickle for metadata or object arrays."""
+  with np.load(path, allow_pickle=False) as archive:
+    return {key: archive[key] for key in archive.files}
+
+
+def _frame_count(capture: dict[str, np.ndarray]) -> int:
+  if "time" not in capture or capture["time"].ndim != 1:
+    raise ValueError("capture must contain a one-dimensional time array")
+  count = len(capture["time"])
+  if count < 2:
+    raise ValueError("capture must contain at least two frames")
+  return count
+
+
+def _event_indices(capture: dict[str, np.ndarray]) -> dict[str, list[int]]:
+  """Return all detected event frame indices from contacts or jump state."""
+  count = _frame_count(capture)
+  events: dict[str, list[int]] = {"start": [0], "end": [count - 1]}
+  jump_state = capture.get("jump_state")
+  if jump_state is not None and jump_state.ndim == 2 and jump_state.shape[1] >= 3:
+    events["takeoff"] = np.flatnonzero(jump_state[:, 1] > 0.5).tolist()
+    events["landing"] = np.flatnonzero(jump_state[:, 2] > 0.5).tolist()
+  contacts = capture.get("contacts")
+  if contacts is not None and contacts.ndim == 2 and contacts.shape[1] >= 2:
+    supported = np.all(contacts[:, :2] > 0.5, axis=1)
+    takeoff = np.flatnonzero(supported[:-1] & ~supported[1:]) + 1
+    landing = np.flatnonzero(~supported[:-1] & supported[1:]) + 1
+    events.setdefault("takeoff", takeoff.tolist())
+    events.setdefault("landing", landing.tolist())
+  return {name: indices for name, indices in events.items() if indices}
+
+
+def detect_events(capture: dict[str, np.ndarray]) -> list[dict[str, Any]]:
+  """Return named event markers with frame and source-time fields."""
+  times = np.asarray(capture["time"], dtype=np.float64)
+  return [
+    {"name": name, "frame": frame, "source_time": float(times[frame])}
+    for name, indices in _event_indices(capture).items()
+    for frame in indices
+  ]
+
+
+def _metadata(capture: dict[str, np.ndarray]) -> dict[str, str]:
+  metadata = {}
+  for key, value in capture.items():
+    if key.startswith("meta_") and value.ndim == 0:
+      metadata[key[5:]] = str(value.item())
+  return metadata
+
+
+def _slice_capture(capture: dict[str, np.ndarray], start: int, end: int) -> dict[str, np.ndarray]:
+  result: dict[str, np.ndarray] = {}
+  count = end - start + 1
+  for key, value in capture.items():
+    if key.startswith("meta_") or value.ndim == 0 or len(value) != _frame_count(capture):
+      result[key] = value.copy()
+    elif len(value) == count and start == 0 and end == len(value) - 1:
+      result[key] = value.copy()
+    else:
+      result[key] = value[start : end + 1].copy()
+  result["source_time"] = capture["time"][start : end + 1].copy()
+  result["time"] = result["source_time"] - result["source_time"][0]
+  return result
+
+
+def _resample_capture(capture: dict[str, np.ndarray], fps: float) -> dict[str, np.ndarray]:
+  if fps <= 0.0:
+    raise ValueError("fps must be positive")
+  source_time = np.asarray(capture["time"], dtype=np.float64)
+  if np.any(np.diff(source_time) <= 0.0):
+    raise ValueError("capture time must be strictly increasing")
+  target_time = np.arange(0.0, source_time[-1] + 1.0e-9, 1.0 / fps)
+  if target_time[-1] < source_time[-1] - 1.0e-9:
+    target_time = np.append(target_time, source_time[-1])
+  result: dict[str, np.ndarray] = {"time": target_time}
+  discrete = {"contacts", "jump_state"}
+  for key, value in capture.items():
+    if key in {"time", "source_time"} or key.startswith("meta_") or value.ndim == 0:
+      if key not in {"time", "source_time"}:
+        result[key] = value.copy()
+      continue
+    if len(value) != len(source_time):
+      result[key] = value.copy()
+      continue
+    if key in discrete:
+      indices = np.searchsorted(source_time, target_time, side="left").clip(max=len(source_time) - 1)
+      result[key] = value[indices]
+      continue
+    flat = value.reshape(len(value), -1).astype(np.float64)
+    interpolated = np.column_stack(
+      [np.interp(target_time, source_time, flat[:, column]) for column in range(flat.shape[1])]
+    ).reshape((len(target_time),) + value.shape[1:])
+    if key == "root_quat":
+      norms = np.linalg.norm(interpolated, axis=1, keepdims=True).clip(min=1.0e-12)
+      interpolated /= norms
+    result[key] = interpolated.astype(value.dtype, copy=False)
+  return result
+
+
+def process_capture(
+  capture: dict[str, np.ndarray],
+  *,
+  fps: float | None = None,
+  event: str = "all",
+  pre_roll: float = 0.5,
+  post_roll: float = 0.5,
+) -> dict[str, np.ndarray]:
+  """Trim around the first named event and optionally resample the result."""
+  if pre_roll < 0.0 or post_roll < 0.0:
+    raise ValueError("pre_roll and post_roll must be non-negative")
+  events = detect_events(capture)
+  if event in {"all", "start", "end"}:
+    start, end = 0, _frame_count(capture) - 1
+  else:
+    matches = [marker for marker in events if marker["name"] == event]
+    if not matches:
+      raise ValueError(f"event {event!r} was not found in the capture")
+    source_time = np.asarray(capture["time"], dtype=np.float64)
+    center = matches[0]["frame"]
+    # Account for decimal timestamp representation at exact frame boundaries.
+    epsilon = 1.0e-9
+    start = int(np.searchsorted(source_time, source_time[center] - pre_roll - epsilon, side="left"))
+    end = int(np.searchsorted(source_time, source_time[center] + post_roll + epsilon, side="right") - 1)
+    end = min(end, len(source_time) - 1)
+  result = _slice_capture(capture, start, end)
+  if fps is not None:
+    result = _resample_capture(result, fps)
+  if "root_pos" in result:
+    result["root_motion"] = result["root_pos"] - result["root_pos"][0]
+  if "joint_pos" in result:
+    result["joint_pos_local"] = result["joint_pos"] - result["joint_pos"][0]
+  selected_start = float(capture["time"][start])
+  selected_end = float(capture["time"][end])
+  markers = [
+    {**marker, "clip_time": marker["source_time"] - selected_start}
+    for marker in events
+    if selected_start <= marker["source_time"] <= selected_end
+  ]
+  result["clip_events_json"] = np.asarray(json.dumps(markers, sort_keys=True))
+  result["clip_metadata_json"] = np.asarray(
+    json.dumps(
+      {
+        **_metadata(capture),
+        "source_frame_count": _frame_count(capture),
+        "source_duration_s": float(capture["time"][-1] - capture["time"][0]),
+        "clip_duration_s": float(result["time"][-1]),
+        "clip_fps": float(1.0 / np.median(np.diff(result["time"]))) if len(result["time"]) > 1 else None,
+        "trim_event": event,
+      },
+      sort_keys=True,
+    )
+  )
+  return result
+
+
+def save_capture(path: Path, capture: dict[str, np.ndarray]) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  np.savez_compressed(path, **capture)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("input", type=Path)
+  parser.add_argument("--output", type=Path, default=None)
+  parser.add_argument("--fps", type=float, default=None, help="Optional animation output FPS")
+  parser.add_argument("--event", default="all", choices=("all", "takeoff", "landing"))
+  parser.add_argument("--pre-roll", type=float, default=0.5)
+  parser.add_argument("--post-roll", type=float, default=0.5)
+  args = parser.parse_args()
+  if not args.input.is_file():
+    parser.error(f"capture does not exist: {args.input}")
+  output = args.output or args.input.with_name(f"{args.input.stem}_clip.npz")
+  save_capture(
+    output,
+    process_capture(
+      load_capture(args.input),
+      fps=args.fps,
+      event=args.event,
+      pre_roll=args.pre_roll,
+      post_roll=args.post_roll,
+    ),
+  )
+  print(output)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/ascento_mjlab/tools/motion_quality.py
+++ b/src/ascento_mjlab/tools/motion_quality.py
@@ -1,0 +1,106 @@
+"""Compute motion-quality metrics and rank captured animation candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from .clip_motion import load_capture
+
+
+def _derivative(values: np.ndarray, time: np.ndarray) -> np.ndarray:
+  return np.gradient(values, time, axis=0, edge_order=1)
+
+
+def _rms(values: np.ndarray) -> float:
+  return float(np.sqrt(np.mean(np.square(values))))
+
+
+def compute_motion_quality(capture: dict[str, np.ndarray]) -> dict[str, Any]:
+  """Return quality metrics without conflating them with task success."""
+  time = np.asarray(capture["time"], dtype=np.float64)
+  if len(time) < 2 or np.any(np.diff(time) <= 0.0):
+    raise ValueError("capture time must be strictly increasing")
+  report: dict[str, Any] = {
+    "finite": all(np.isfinite(value).all() for value in capture.values() if value.dtype.kind in "fiu"),
+    "duration_s": float(time[-1] - time[0]),
+    "frame_count": len(time),
+  }
+  if "root_pos" in capture:
+    velocity = _derivative(capture["root_pos"].astype(np.float64), time)
+    acceleration = _derivative(velocity, time)
+    jerk = _derivative(acceleration, time)
+    report.update(
+      root_speed_rms_mps=_rms(np.linalg.norm(velocity, axis=1)),
+      root_acceleration_rms_mps2=_rms(np.linalg.norm(acceleration, axis=1)),
+      root_jerk_rms_mps3=_rms(np.linalg.norm(jerk, axis=1)),
+    )
+  for source, prefix in (("action", "action"), ("effort", "torque")):
+    if source not in capture:
+      continue
+    values = capture[source].astype(np.float64)
+    first = _derivative(values, time)
+    second = _derivative(first, time)
+    third = _derivative(second, time)
+    report[f"{prefix}_rms"] = _rms(values)
+    report[f"{prefix}_peak"] = float(np.max(np.abs(values)))
+    report[f"{prefix}_jerk_rms"] = _rms(third)
+  if "joint_pos" in capture:
+    joint_acceleration = _derivative(_derivative(capture["joint_pos"].astype(np.float64), time), time)
+    report["joint_acceleration_rms_rad_s2"] = _rms(joint_acceleration)
+  if "contacts" in capture:
+    contacts = capture["contacts"] > 0.5
+    report["contact_toggle_count"] = int(np.count_nonzero(np.any(contacts[1:] != contacts[:-1], axis=1)))
+    report["contact_toggle_rate_hz"] = float(report["contact_toggle_count"] / report["duration_s"])
+  report["quality_score"] = _quality_score(report)
+  return report
+
+
+def _quality_score(report: dict[str, Any]) -> float:
+  """Higher is smoother; this score is for ranking, not task acceptance."""
+  penalty = 0.0
+  penalty += report.get("root_jerk_rms_mps3", 0.0) / 10.0
+  penalty += report.get("torque_jerk_rms", 0.0) / 1000.0
+  penalty += report.get("action_jerk_rms", 0.0) / 10.0
+  penalty += report.get("contact_toggle_rate_hz", 0.0) / 20.0
+  return 0.0 if not report["finite"] else float(1.0 / (1.0 + penalty))
+
+
+def rank_capture_files(paths: Iterable[Path]) -> list[dict[str, Any]]:
+  reports = []
+  for path in sorted(paths):
+    report = compute_motion_quality(load_capture(path))
+    reports.append({"path": str(path), **report})
+  return sorted(reports, key=lambda item: (-item["quality_score"], item["path"]))
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("inputs", nargs="+", type=Path, help="Capture files or directories")
+  parser.add_argument("--top", type=int, default=None)
+  parser.add_argument("--output", type=Path, default=None)
+  args = parser.parse_args()
+  paths = []
+  for item in args.inputs:
+    paths.extend(sorted(item.glob("*.npz")) if item.is_dir() else [item])
+  if not paths or any(not path.is_file() for path in paths):
+    parser.error("inputs must contain existing NPZ captures")
+  reports = rank_capture_files(paths)
+  if args.top is not None:
+    if args.top < 1:
+      parser.error("--top must be positive")
+    reports = reports[: args.top]
+  payload = json.dumps(reports, indent=2, sort_keys=True)
+  if args.output is not None:
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(payload + "\n", encoding="utf-8")
+  else:
+    print(payload)
+
+
+if __name__ == "__main__":
+  main()

--- a/tests_mjlab/test_motion_tools.py
+++ b/tests_mjlab/test_motion_tools.py
@@ -1,0 +1,62 @@
+import json
+
+import numpy as np
+
+from ascento_mjlab.tools.clip_motion import detect_events, process_capture, save_capture
+from ascento_mjlab.tools.motion_quality import compute_motion_quality, rank_capture_files
+
+
+def _capture() -> dict[str, np.ndarray]:
+  time = np.arange(0.0, 1.0, 0.1)
+  contacts = np.ones((len(time), 2), dtype=np.float32)
+  contacts[3:7] = 0.0
+  return {
+    "time": time,
+    "root_pos": np.column_stack((time, np.zeros((len(time), 2)))),
+    "root_quat": np.tile(np.asarray([1.0, 0.0, 0.0, 0.0]), (len(time), 1)),
+    "joint_pos": np.zeros((len(time), 6)),
+    "action": np.zeros((len(time), 6)),
+    "effort": np.zeros((len(time), 6)),
+    "contacts": contacts,
+    "meta_task": np.asarray("test"),
+  }
+
+
+def test_detect_events_uses_two_wheel_contact_transitions():
+  events = detect_events(_capture())
+  assert [(event["name"], event["frame"]) for event in events] == [
+    ("start", 0),
+    ("end", 9),
+    ("takeoff", 3),
+    ("landing", 7),
+  ]
+
+
+def test_process_capture_trims_resamples_and_separates_motion():
+  result = process_capture(_capture(), event="takeoff", pre_roll=0.1, post_roll=0.3, fps=20.0)
+  assert len(result["time"]) == 9
+  assert result["time"][0] == 0.0
+  assert result["root_motion"].shape == result["root_pos"].shape
+  assert result["joint_pos_local"].shape == result["joint_pos"].shape
+  markers = json.loads(str(result["clip_events_json"].item()))
+  assert any(marker["name"] == "takeoff" for marker in markers)
+
+
+def test_motion_quality_reports_smoothness_separately_from_success():
+  report = compute_motion_quality(_capture())
+  assert report["finite"] is True
+  assert report["duration_s"] == 0.9
+  assert report["contact_toggle_count"] == 2
+  assert 0.0 < report["quality_score"] <= 1.0
+
+
+def test_rank_capture_files_returns_best_first(tmp_path):
+  first = tmp_path / "first.npz"
+  second = tmp_path / "second.npz"
+  save_capture(first, _capture())
+  noisy = _capture()
+  noisy["root_pos"][:, 0] = np.asarray([0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+  save_capture(second, noisy)
+  reports = rank_capture_files([second, first])
+  assert {report["path"] for report in reports} == {str(first), str(second)}
+  assert reports[0]["quality_score"] >= reports[1]["quality_score"]

--- a/uv.lock
+++ b/uv.lock
@@ -96,13 +96,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", marker = "extra == 'dashboard'", specifier = ">=0.115.0" },
+    { name = "fastapi", marker = "extra == 'dashboard'", specifier = "==0.141.1" },
     { name = "mjlab", specifier = "==1.6.0" },
     { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = ">=2.7.0" },
     { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cu128'", specifier = ">=2.7.0" },
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cpu'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "ascento-mjlab", extra = "cpu" } },
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cu128'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "ascento-mjlab", extra = "cu128" } },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dashboard'", specifier = ">=0.34.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dashboard'", specifier = "==0.52.4" },
 ]
 provides-extras = ["cu128", "cpu", "dashboard"]
 


### PR DESCRIPTION
## Summary
This focused pass addresses three issues that remain applicable after the mjlab migration:

- Closes #50: pin FastAPI/Uvicorn in the uv lockfile and install the dashboard extra in Docker.
- Closes #31: add RecorderManager metadata, contact/jump channels, event-aware clip trimming, and animation-rate resampling.
- Closes #32: add documented motion-quality metrics and batch capture ranking for visual review.

The quality score remains separate from task-success acceptance; terrain and the superseded legacy JAX evaluator issues are not included.

## Validation
- `pytest -q --capture=no tests_mjlab` — 16 passed
- `ruff check src/ascento_mjlab/tools tests_mjlab`
- `uv lock --check --offline`
- End-to-end capture smoke with checkpoint metadata
- Clip generation and batch ranking smoke checks
