### PR TITLE
Fix headless MuJoCo imports in CI

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -19,6 +19,11 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    env:
+      # mjlab defaults to EGL on Linux, but GitHub-hosted runners do not
+      # provide a usable EGL runtime. These tests do not render, so disable
+      # MuJoCo's GL backend explicitly, matching mjlab's own CI smoke tests.
+      MUJOCO_GL: disable
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- disable MuJoCo's GL backend in the GitHub Actions backend test job
- avoid mjlab's Linux default of `MUJOCO_GL=egl` on GitHub-hosted runners without a usable EGL runtime
- keep the test environment aligned with mjlab's own non-rendering CI strategy

## Root cause
The new import-order tests run each import sequence in a fresh Python subprocess. In those clean subprocesses, importing `mjlab` first sets `MUJOCO_GL=egl`, after which MuJoCo imports PyOpenGL's EGL bindings. The GitHub-hosted runner does not provide a usable EGL runtime, so the subprocess exits with `AttributeError: 'NoneType' object has no attribute 'eglQueryString'` before the task-registration assertions are reached.

The existing pytest process could hide this because some tests import `mujoco` before `mjlab`, causing MuJoCo to select its GL backend before mjlab sets the EGL default.

## Fix
Set `MUJOCO_GL=disable` for the backend CI job. These tests do not render, and mjlab's upstream CI uses the same approach for headless import/smoke tests.

## Validation
Opening this PR changes `.github/workflows/dashboard-ci.yml`, so the Dashboard CI workflow is triggered on the PR and will exercise the previously failing `tests_mjlab/test_import_order.py` cases.