### PR TITLE
Pass 2: fix capture and clip pipeline regressions

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v6
-      - run: uv run --frozen --extra cpu pytest -q tests_mjlab
+      - run: uv run --frozen --extra cpu python -m pytest -q tests_mjlab
 
   dashboard-backend:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v6
-      - run: uv run --frozen --extra cpu --extra dashboard pytest -q tests_dashboard
+      - run: uv run --frozen --extra cpu --extra dashboard python -m pytest -q tests_dashboard
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     paths:
       - 'dashboard/**'
+      - 'src/ascento_mjlab/tools/**'
       - 'tests_mjlab/**'
+      - 'tests_dashboard/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/dashboard-ci.yml'
   push:
     paths:
       - 'dashboard/**'
+      - 'src/ascento_mjlab/tools/**'
       - 'tests_mjlab/**'
+      - 'tests_dashboard/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/dashboard-ci.yml'
@@ -29,9 +33,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: python -m pip install --upgrade pip
-      - run: pip install . pytest
-      - run: python -m pytest -q tests_mjlab
+      - uses: astral-sh/setup-uv@v6
+      - run: uv run --frozen --extra cpu pytest -q tests_mjlab
+
+  dashboard-backend:
+    runs-on: ubuntu-latest
+    env:
+      MUJOCO_GL: disable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v6
+      - run: uv run --frozen --extra cpu --extra dashboard pytest -q tests_dashboard
 
   frontend:
     runs-on: ubuntu-latest

--- a/src/ascento_mjlab/tools/capture_motion.py
+++ b/src/ascento_mjlab/tools/capture_motion.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -16,6 +17,45 @@ from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.utils.wrappers import VideoRecorder
 
 import ascento_mjlab.tasks  # noqa: F401
+
+
+def _jump_state_array(state: dict[str, torch.Tensor]) -> np.ndarray:
+  """Copy the four jump-state scalars to host memory as one float32 vector."""
+  values = torch.stack(
+    [
+      state["airborne"][0],
+      state["takeoff"][0],
+      state["landing"][0],
+      state["air_time"][0],
+    ]
+  )
+  return values.detach().to(device="cpu", dtype=torch.float32).numpy().copy()
+
+
+def _configure_capture_cfg(cfg: Any, *, take: int) -> Any:
+  """Configure a task for one continuous, non-auto-reset capture take."""
+  cfg.scene.num_envs = 1
+  cfg.seed = take
+  # A capture is one continuous trajectory. Auto-reset would make record_post_step()
+  # observe the reset pose after a terminal step and splice it into the same take.
+  cfg.auto_reset = False
+  cfg.recorders = {"motion": RecorderTermCfg(func=MotionRecorder, params={})}
+  return cfg
+
+
+def _run_capture_steps(
+  env: Any,
+  policy: Callable[[Any], torch.Tensor],
+  *,
+  steps: int,
+) -> tuple[int, bool]:
+  """Run until the requested length or the first terminal/truncated step."""
+  obs, _ = env.reset()
+  for step in range(1, steps + 1):
+    obs, _, dones, _ = env.step(policy(obs))
+    if bool(torch.any(dones).item()):
+      return step, True
+  return steps, False
 
 
 class MotionRecorder(RecorderTerm):
@@ -48,11 +88,7 @@ class MotionRecorder(RecorderTerm):
     if len(contacts) == 2:
       frame["contacts"] = np.asarray(contacts, dtype=np.float32)
     if hasattr(env, "ascento_jump_state"):
-      state = env.ascento_jump_state
-      frame["jump_state"] = np.asarray(
-        [state["airborne"][0], state["takeoff"][0], state["landing"][0], state["air_time"][0]],
-        dtype=np.float32,
-      )
+      frame["jump_state"] = _jump_state_array(env.ascento_jump_state)
     for command_name in ("motion", "twist"):
       try:
         command = env.command_manager.get_command(command_name)
@@ -93,10 +129,7 @@ def main() -> None:
     checkpoint_hash = hashlib.sha256(args.checkpoint.read_bytes()).hexdigest()
 
   for take in range(args.takes):
-    cfg = load_env_cfg(args.task, play=True)
-    cfg.scene.num_envs = 1
-    cfg.seed = take
-    cfg.recorders = {"motion": RecorderTermCfg(func=MotionRecorder, params={})}
+    cfg = _configure_capture_cfg(load_env_cfg(args.task, play=True), take=take)
     base_env = ManagerBasedRlEnv(
       cfg,
       device=args.device,
@@ -116,9 +149,11 @@ def main() -> None:
     )
     env = RslRlVecEnvWrapper(raw_env, clip_actions=load_rl_cfg(args.task).clip_actions)
     if args.checkpoint is None:
+
       def policy(obs):
         del obs
         return torch.zeros((1, 6), device=args.device)
+
     else:
       agent_cfg = load_rl_cfg(args.task)
       runner_cls = load_runner_cls(args.task) or MjlabOnPolicyRunner
@@ -130,19 +165,19 @@ def main() -> None:
         map_location=args.device,
       )
       policy = runner.get_inference_policy(device=args.device)
-    obs, _ = env.reset()
-    for _ in range(args.steps):
-      obs, _, _, _ = env.step(policy(obs))
-    recorder = raw_env.recorder_manager.get_term("motion")
+    captured_steps, ended_on_done = _run_capture_steps(env, policy, steps=args.steps)
+    recorder = base_env.recorder_manager.get_term("motion")
     recorder.export(
       args.output_dir / f"take_{take:03d}.npz",
       metadata={
         "task": args.task,
         "seed": str(take),
-        "fps": str(round(1.0 / raw_env.step_dt)),
+        "fps": str(round(1.0 / base_env.step_dt)),
         "checkpoint": str(args.checkpoint) if args.checkpoint is not None else "",
         "model_sha256": checkpoint_hash,
         "physics_profile": "animation_high_authority",
+        "captured_steps": str(captured_steps),
+        "ended_on_done": str(ended_on_done).lower(),
       },
     )
     env.close()

--- a/src/ascento_mjlab/tools/clip_motion.py
+++ b/src/ascento_mjlab/tools/clip_motion.py
@@ -26,20 +26,28 @@ def _frame_count(capture: dict[str, np.ndarray]) -> int:
 
 
 def _event_indices(capture: dict[str, np.ndarray]) -> dict[str, list[int]]:
-  """Return all detected event frame indices from contacts or jump state."""
+  """Return all detected event frame indices from jump state or contact fallback."""
   count = _frame_count(capture)
   events: dict[str, list[int]] = {"start": [0], "end": [count - 1]}
   jump_state = capture.get("jump_state")
   if jump_state is not None and jump_state.ndim == 2 and jump_state.shape[1] >= 3:
-    events["takeoff"] = np.flatnonzero(jump_state[:, 1] > 0.5).tolist()
-    events["landing"] = np.flatnonzero(jump_state[:, 2] > 0.5).tolist()
+    takeoff = np.flatnonzero(jump_state[:, 1] > 0.5).tolist()
+    landing = np.flatnonzero(jump_state[:, 2] > 0.5).tolist()
+    if takeoff:
+      events["takeoff"] = takeoff
+    if landing:
+      events["landing"] = landing
   contacts = capture.get("contacts")
   if contacts is not None and contacts.ndim == 2 and contacts.shape[1] >= 2:
     supported = np.all(contacts[:, :2] > 0.5, axis=1)
-    takeoff = np.flatnonzero(supported[:-1] & ~supported[1:]) + 1
-    landing = np.flatnonzero(~supported[:-1] & supported[1:]) + 1
-    events.setdefault("takeoff", takeoff.tolist())
-    events.setdefault("landing", landing.tolist())
+    takeoff = (np.flatnonzero(supported[:-1] & ~supported[1:]) + 1).tolist()
+    landing = (np.flatnonzero(~supported[:-1] & supported[1:]) + 1).tolist()
+    # Jump-state event pulses are authoritative when present. Contacts fill only
+    # missing event types so an empty jump_state channel cannot suppress fallback.
+    if takeoff and not events.get("takeoff"):
+      events["takeoff"] = takeoff
+    if landing and not events.get("landing"):
+      events["landing"] = landing
   return {name: indices for name, indices in events.items() if indices}
 
 
@@ -96,7 +104,10 @@ def _resample_capture(capture: dict[str, np.ndarray], fps: float) -> dict[str, n
       result[key] = value.copy()
       continue
     if key in discrete:
-      indices = np.searchsorted(source_time, target_time, side="left").clip(max=len(source_time) - 1)
+      # Zero-order hold: keep the most recent source sample until its successor's
+      # timestamp. side="right" preserves transitions at the original sample time.
+      indices = np.searchsorted(source_time, target_time, side="right") - 1
+      indices = indices.clip(min=0, max=len(source_time) - 1)
       result[key] = value[indices]
       continue
     flat = value.reshape(len(value), -1).astype(np.float64)
@@ -132,8 +143,12 @@ def process_capture(
     center = matches[0]["frame"]
     # Account for decimal timestamp representation at exact frame boundaries.
     epsilon = 1.0e-9
-    start = int(np.searchsorted(source_time, source_time[center] - pre_roll - epsilon, side="left"))
-    end = int(np.searchsorted(source_time, source_time[center] + post_roll + epsilon, side="right") - 1)
+    start = int(
+      np.searchsorted(source_time, source_time[center] - pre_roll - epsilon, side="left")
+    )
+    end = int(
+      np.searchsorted(source_time, source_time[center] + post_roll + epsilon, side="right") - 1
+    )
     end = min(end, len(source_time) - 1)
   result = _slice_capture(capture, start, end)
   if fps is not None:
@@ -157,7 +172,11 @@ def process_capture(
         "source_frame_count": _frame_count(capture),
         "source_duration_s": float(capture["time"][-1] - capture["time"][0]),
         "clip_duration_s": float(result["time"][-1]),
-        "clip_fps": float(1.0 / np.median(np.diff(result["time"]))) if len(result["time"]) > 1 else None,
+        "clip_fps": (
+          float(1.0 / np.median(np.diff(result["time"])))
+          if len(result["time"]) > 1
+          else None
+        ),
         "trim_event": event,
       },
       sort_keys=True,

--- a/tests_dashboard/test_backend.py
+++ b/tests_dashboard/test_backend.py
@@ -1,0 +1,13 @@
+import importlib
+
+
+def test_dashboard_backend_imports_and_registers_health_route(monkeypatch, tmp_path):
+  monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(tmp_path))
+  module = importlib.import_module("dashboard.app")
+
+  assert module.app.title == "Ascento Training Monitor"
+  assert any(route.path == "/api/health" for route in module.app.routes)
+  assert module.health() == {
+    "ok": True,
+    "artifact_root": str(tmp_path.resolve()),
+  }

--- a/tests_mjlab/test_capture_motion.py
+++ b/tests_mjlab/test_capture_motion.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from ascento_mjlab.tools.capture_motion import (
+  _configure_capture_cfg,
+  _jump_state_array,
+  _run_capture_steps,
+)
+
+
+def _jump_state(device: str) -> dict[str, torch.Tensor]:
+  return {
+    "airborne": torch.tensor([True], device=device),
+    "takeoff": torch.tensor([False], device=device),
+    "landing": torch.tensor([True], device=device),
+    "air_time": torch.tensor([0.25], device=device),
+  }
+
+
+def test_jump_state_serialization_copies_tensors_to_cpu():
+  result = _jump_state_array(_jump_state("cpu"))
+  assert result.dtype == np.float32
+  np.testing.assert_allclose(result, np.asarray([1.0, 0.0, 1.0, 0.25], dtype=np.float32))
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_jump_state_serialization_accepts_cuda_tensors():
+  result = _jump_state_array(_jump_state("cuda:0"))
+  assert result.dtype == np.float32
+  np.testing.assert_allclose(result, np.asarray([1.0, 0.0, 1.0, 0.25], dtype=np.float32))
+
+
+def test_capture_configuration_disables_auto_reset():
+  cfg = SimpleNamespace(
+    scene=SimpleNamespace(num_envs=8),
+    seed=None,
+    auto_reset=True,
+    recorders={},
+  )
+  configured = _configure_capture_cfg(cfg, take=3)
+  assert configured is cfg
+  assert configured.scene.num_envs == 1
+  assert configured.seed == 3
+  assert configured.auto_reset is False
+  assert set(configured.recorders) == {"motion"}
+
+
+def test_capture_rollout_stops_at_first_done_state():
+  class FakeEnv:
+    def __init__(self):
+      self.steps = 0
+
+    def reset(self):
+      return torch.zeros((1, 1)), {}
+
+    def step(self, action):
+      del action
+      self.steps += 1
+      obs = torch.full((1, 1), float(self.steps))
+      reward = torch.zeros(1)
+      done = torch.tensor([self.steps >= 2], dtype=torch.long)
+      return obs, reward, done, {}
+
+  env = FakeEnv()
+  captured_steps, ended_on_done = _run_capture_steps(
+    env,
+    lambda obs: torch.zeros((len(obs), 6)),
+    steps=10,
+  )
+  assert captured_steps == 2
+  assert ended_on_done is True
+  assert env.steps == 2

--- a/tests_mjlab/test_motion_cli.py
+++ b/tests_mjlab/test_motion_cli.py
@@ -1,0 +1,71 @@
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+from ascento_mjlab.tools.clip_motion import save_capture
+
+
+def _capture() -> dict[str, np.ndarray]:
+  time = np.asarray([0.0, 0.1, 0.2, 0.3], dtype=np.float64)
+  return {
+    "time": time,
+    "root_pos": np.column_stack((time, np.zeros((len(time), 2)))),
+    "root_quat": np.tile(np.asarray([1.0, 0.0, 0.0, 0.0]), (len(time), 1)),
+    "joint_pos": np.zeros((len(time), 6), dtype=np.float32),
+    "action": np.zeros((len(time), 6), dtype=np.float32),
+    "effort": np.zeros((len(time), 6), dtype=np.float32),
+    "contacts": np.asarray([[1, 1], [1, 1], [0, 0], [0, 0]], dtype=np.float32),
+    "jump_state": np.zeros((len(time), 4), dtype=np.float32),
+    "meta_task": np.asarray("cli-fixture"),
+  }
+
+
+def _run_module(*args: str) -> subprocess.CompletedProcess[str]:
+  env = os.environ.copy()
+  env["MUJOCO_GL"] = "disable"
+  return subprocess.run(
+    [sys.executable, "-m", *args],
+    env=env,
+    capture_output=True,
+    text=True,
+    check=False,
+  )
+
+
+def test_capture_cli_imports_on_cpu_safe_help_path():
+  result = _run_module("ascento_mjlab.tools.capture_motion", "--help")
+  assert result.returncode == 0, result.stderr
+  assert "--device" in result.stdout
+
+
+def test_clip_and_rank_clis_process_representative_npz(tmp_path):
+  source = tmp_path / "capture.npz"
+  clipped = tmp_path / "capture_clip.npz"
+  report = tmp_path / "ranking.json"
+  save_capture(source, _capture())
+
+  clip_result = _run_module(
+    "ascento_mjlab.tools.clip_motion",
+    str(source),
+    "--output",
+    str(clipped),
+    "--fps",
+    "20",
+  )
+  assert clip_result.returncode == 0, clip_result.stderr
+  assert clipped.is_file()
+
+  rank_result = _run_module(
+    "ascento_mjlab.tools.motion_quality",
+    str(clipped),
+    "--output",
+    str(report),
+  )
+  assert rank_result.returncode == 0, rank_result.stderr
+  payload = json.loads(report.read_text(encoding="utf-8"))
+  assert len(payload) == 1
+  assert payload[0]["path"] == str(clipped)
+  assert payload[0]["finite"] is True

--- a/tests_mjlab/test_motion_tools.py
+++ b/tests_mjlab/test_motion_tools.py
@@ -32,6 +32,21 @@ def test_detect_events_uses_two_wheel_contact_transitions():
   ]
 
 
+def test_detect_events_falls_back_when_jump_state_has_no_event_pulses():
+  capture = {
+    "time": np.asarray([0.0, 0.1, 0.2]),
+    "contacts": np.asarray([[1, 1], [0, 0], [1, 1]], dtype=np.float32),
+    "jump_state": np.zeros((3, 4), dtype=np.float32),
+  }
+  events = detect_events(capture)
+  assert [(event["name"], event["frame"]) for event in events] == [
+    ("start", 0),
+    ("end", 2),
+    ("takeoff", 1),
+    ("landing", 2),
+  ]
+
+
 def test_process_capture_trims_resamples_and_separates_motion():
   result = process_capture(_capture(), event="takeoff", pre_roll=0.1, post_roll=0.3, fps=20.0)
   assert len(result["time"]) == 9
@@ -40,6 +55,27 @@ def test_process_capture_trims_resamples_and_separates_motion():
   assert result["joint_pos_local"].shape == result["joint_pos"].shape
   markers = json.loads(str(result["clip_events_json"].item()))
   assert any(marker["name"] == "takeoff" for marker in markers)
+
+
+def test_discrete_resampling_uses_previous_sample_zero_order_hold():
+  capture = {
+    "time": np.asarray([0.0, 0.1]),
+    "contacts": np.asarray([[1, 1], [0, 0]], dtype=np.float32),
+    "jump_state": np.asarray([[0, 0, 0, 0], [1, 1, 0, 0.1]], dtype=np.float32),
+  }
+  result = process_capture(capture, fps=20.0)
+  np.testing.assert_allclose(result["time"], np.asarray([0.0, 0.05, 0.1]))
+  np.testing.assert_array_equal(
+    result["contacts"],
+    np.asarray([[1, 1], [1, 1], [0, 0]], dtype=np.float32),
+  )
+  np.testing.assert_array_equal(
+    result["jump_state"],
+    np.asarray(
+      [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 0, 0.1]],
+      dtype=np.float32,
+    ),
+  )
 
 
 def test_motion_quality_reports_smoothness_separately_from_success():


### PR DESCRIPTION
## Summary

This is the coordinated Pass 2 capture/clip correctness pass.

- make jump-state serialization device-safe by copying the stacked state tensor to CPU before NumPy conversion
- disable mjlab auto-reset for motion capture and stop each take at the first terminal/truncated step, so reset poses cannot be concatenated into one trajectory
- use contact transitions as a per-event fallback when jump-state pulses are absent
- resample discrete `contacts` and `jump_state` channels with previous-sample zero-order hold so transitions are not shifted early
- add regression coverage for all four bugs, including an optional CUDA serialization test
- add CPU-safe subprocess coverage for capture help, clip processing, and motion ranking using representative NPZ fixtures
- add a dashboard-extra backend import/health test job
- run backend CI through the repo's `uv` CPU extra instead of plain pip, avoiding accidental CUDA PyTorch resolution on GitHub-hosted CPU runners

## Capture contract

A saved take now represents exactly one continuous episode. `auto_reset=False` leaves the terminal state intact for `record_post_step()`, and the capture loop exits immediately when RSL-RL reports done. The next take creates/resets its own environment rather than splicing a reset into the previous NPZ.

## Regression coverage

- CPU and optional CUDA jump-state serialization
- capture configuration forces `auto_reset=False`
- capture loop stops on first done
- empty `jump_state` still falls back to contact takeoff/landing events
- 20 FPS discrete resampling preserves a transition at 0.1 s instead of moving it to 0.05 s
- representative NPZ passes through clip and rank CLIs
- existing subprocess task import-order coverage remains in the normal backend suite
- dashboard backend imports with the declared `dashboard` extra and exposes `/api/health`

Fixes #54
Fixes #55
Fixes #56
Fixes #60
Fixes #61