### PR TITLE
Dashboard: reliability, training health, and reproducibility (Pass 4A–4C)

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'dashboard/**'
+      - 'scripts/run_dashboard.sh'
       - 'src/ascento_mjlab/tools/**'
       - 'tests_mjlab/**'
       - 'tests_dashboard/**'
@@ -13,6 +14,7 @@ on:
   push:
     paths:
       - 'dashboard/**'
+      - 'scripts/run_dashboard.sh'
       - 'src/ascento_mjlab/tools/**'
       - 'tests_mjlab/**'
       - 'tests_dashboard/**'
@@ -46,6 +48,7 @@ jobs:
         with:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v6
+      - run: bash -n scripts/run_dashboard.sh
       - run: uv run --frozen --extra cpu --extra dashboard python -m pytest -q tests_dashboard
 
   frontend:

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,39 +1,60 @@
 # Ascento Training Dashboard
 
-A small local web dashboard for monitoring mjlab/RSL-RL training over Tailscale.
-It reads run artifacts and does not own or supervise the PPO process itself.
+A local web dashboard for monitoring mjlab/RSL-RL training over Tailscale. It reads
+training artifacts and launcher metadata; it does not own the PPO algorithm itself.
 
 ## What it shows
 
-- current stage, progress, steps/s, elapsed time and ETA from RSL-RL TensorBoard events;
-- TensorBoard/RSL-RL metric artifacts and console output;
-- live captured console output using Server-Sent Events;
-- recent traceback/error excerpts;
-- available RSL-RL checkpoints and motion-capture export location;
-- previous runs discovered under the artifact root.
+- current iteration, wall-clock freshness, throughput, elapsed time and ETA;
+- reward and episode-length trends;
+- PPO/surrogate loss, value loss, entropy, KL, clip fraction and invalid-update telemetry when reported by the trainer;
+- NaN/Inf detection across numeric telemetry;
+- stale-run detection when a run is still marked running but telemetry stops;
+- GPU utilization, memory, temperature, process PID/aliveness and per-process GPU memory when `nvidia-smi` is available;
+- recent traceback/error excerpts and live console output;
+- Git commit/branch, task/stage, seed, command line, timestep/device, checkpoint path, configuration files, start/end time and exit code;
+- a copyable run-information block and downloadable `run-summary.json`;
+- active dashboard configuration plus API health.
 
-Motion export is intentionally a separate `capture-motion` command so capture
-does not compete with training or become a second rollout framework.
+The dashboard and `dashboard.launch` use the same artifact-root configuration.
+The default is:
+
+```text
+<repo>/logs/rsl_rl
+```
+
+Set `ASCENTO_ARTIFACT_ROOT` once to override it for both processes.
 
 ## Install
 
-From the repository root, after installing the project with uv:
+From the repository root:
 
 ```bash
-uv sync --extra cu128 --extra dashboard
+uv sync --frozen --extra cu128 --extra dashboard
 cd dashboard/frontend
 npm install
 npm run build
 cd ../..
 ```
 
+Use `--extra cpu` instead of `--extra cu128` on a CPU-only machine.
+
 For frontend development, run `npm run dev` in `dashboard/frontend`; Vite proxies
 `/api` requests to `127.0.0.1:8000`.
 
 ## Start the dashboard
 
+Use the project interpreter through uv:
+
 ```bash
-python -m uvicorn dashboard.app:app --host 127.0.0.1 --port 8000
+uv run --frozen --extra dashboard python -m uvicorn dashboard.app:app \
+  --host 127.0.0.1 --port 8000
+```
+
+Or use:
+
+```bash
+./scripts/run_dashboard.sh
 ```
 
 The production server intentionally binds only to `127.0.0.1:8000`. To make it
@@ -46,28 +67,61 @@ tailscale serve --bg 8000
 Open the HTTPS Tailscale Serve URL from another device on the same tailnet.
 Do not use Tailscale Funnel for this private monitor.
 
-Set a different artifact location when needed:
+To use a different artifact root:
 
 ```bash
-ASCENTO_ARTIFACT_ROOT=/path/to/logs python -m uvicorn dashboard.app:app --host 127.0.0.1 --port 8000
+ASCENTO_ARTIFACT_ROOT=/path/to/logs \
+  uv run --frozen --extra dashboard python -m uvicorn dashboard.app:app \
+  --host 127.0.0.1 --port 8000
 ```
+
+The API exposes:
+
+- `/api/health` — health indicator and startup/configuration diagnostics;
+- `/api/config` — active dashboard configuration;
+- `/api/runs` — discovered runs;
+- `/api/runs/<id>` — detailed run status, health and reproducibility metadata;
+- `/api/runs/<id>/summary.json` — downloadable run summary;
+- `/api/runs/<id>/telemetry` — normalized training telemetry;
+- `/api/runs/<id>/logs` and `/logs/stream` — captured console output.
+
+`ASCENTO_STALE_AFTER_SECONDS` controls the stale-run threshold and defaults to
+90 seconds.
 
 ## Start a monitored training run
 
-The standard mjlab trainer writes RSL-RL checkpoints and TensorBoard events. To
-capture console output for the dashboard, launch it through:
+Launch training through the same uv-managed environment:
 
 ```bash
-python -m dashboard.launch --task Ascento-Balance-Flat \
+uv run --frozen --extra cu128 python -m dashboard.launch \
+  --task Ascento-Balance-Flat \
   -- --env.scene.num-envs 512 --agent.max-iterations 10000
 ```
 
-The artifacts live under the configured RSL-RL log root. The dashboard treats
-these artifacts as read-only and leaves checkpoint playback/capture to the
-normal mjlab tools.
+`dashboard.launch` captures durable run metadata before starting the trainer,
+including the current Git commit/branch, the exact command, task/stage, seed,
+device and simulation timestep when supplied on the command line. It updates the
+same status record with PID, finish time, exit code and latest checkpoint.
 
-For motion exports, use `capture-motion` after training, for example:
+To override the shared root for both the launcher and server:
 
 ```bash
-capture-motion Ascento-Jump-Flat --checkpoint /path/to/model_10000.pt --takes 20
+ASCENTO_ARTIFACT_ROOT=/path/to/logs \
+  uv run --frozen --extra cu128 python -m dashboard.launch \
+  --task Ascento-Balance-Flat \
+  -- --agent.max-iterations 10000
 ```
+
+For motion exports, keep using the normal post-training tooling, for example:
+
+```bash
+uv run --frozen --extra cu128 capture-motion \
+  Ascento-Jump-Flat --checkpoint /path/to/model_10000.pt --takes 20
+```
+
+## Startup failures
+
+The backend validates its artifact root during startup. If the configured path
+is a file, cannot be created, or cannot be read/searched, startup fails with a
+message naming the bad path and the relevant environment variable. A missing
+frontend build is non-fatal and appears as a startup warning in `/api/health`.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -4,60 +4,133 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from dashboard.monitor import (
-    list_run_summaries,
-    load_training_records,
-    resolve_run,
-    summarize_run,
-    tail_lines,
-    training_log_path,
+from dashboard.config import load_config, validate_startup
+from dashboard.health import (
+    list_dashboard_summaries,
+    load_dashboard_records,
+    resolve_dashboard_run,
+    summarize_dashboard_run,
 )
+from dashboard.monitor import tail_lines, training_log_path
 
-ROOT = Path(__file__).resolve().parents[1]
-ARTIFACT_ROOT = Path(
-    os.environ.get("ASCENTO_ARTIFACT_ROOT", ROOT / "training" / "artifacts")
-).expanduser().resolve()
-FRONTEND_DIST = Path(
-    os.environ.get("ASCENTO_DASHBOARD_DIST", Path(__file__).parent / "frontend" / "dist")
-).expanduser().resolve()
+CONFIG = load_config()
+STARTUP_WARNINGS = validate_startup(CONFIG)
+ARTIFACT_ROOT = CONFIG.artifact_root
+FRONTEND_DIST = CONFIG.frontend_dist
 
-app = FastAPI(title="Ascento Training Monitor", version="1.0")
+app = FastAPI(title="Ascento Training Monitor", version="1.2")
 
 
 def _run(run_id: str):
     try:
-        return resolve_run(ARTIFACT_ROOT, run_id)
+        return resolve_dashboard_run(ARTIFACT_ROOT, run_id)
     except KeyError as error:
         raise HTTPException(status_code=404, detail="training run not found") from error
+    except OSError as error:
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to scan artifact root {ARTIFACT_ROOT}: {error}",
+        ) from error
+
+
+def _artifact_health() -> list[str]:
+    problems: list[str] = []
+    if not ARTIFACT_ROOT.exists():
+        problems.append(f"artifact root does not exist: {ARTIFACT_ROOT}")
+    elif not ARTIFACT_ROOT.is_dir():
+        problems.append(f"artifact root is not a directory: {ARTIFACT_ROOT}")
+    else:
+        if not os.access(ARTIFACT_ROOT, os.R_OK):
+            problems.append(f"artifact root is not readable: {ARTIFACT_ROOT}")
+        if not os.access(ARTIFACT_ROOT, os.X_OK):
+            problems.append(f"artifact root is not searchable: {ARTIFACT_ROOT}")
+    return problems
 
 
 @app.get("/api/health")
 def health():
-    return {"ok": True, "artifact_root": str(ARTIFACT_ROOT)}
+    problems = _artifact_health()
+    try:
+        run_count = len(list_dashboard_summaries(
+            ARTIFACT_ROOT,
+            stale_after_seconds=CONFIG.stale_after_seconds,
+        ))
+    except OSError as error:
+        problems.append(f"artifact scan failed: {error}")
+        run_count = None
+    return {
+        "ok": not problems,
+        "status": "ok" if not problems else "error",
+        "checked_at": time.time(),
+        "artifact_root": str(ARTIFACT_ROOT),
+        "run_count": run_count,
+        "problems": problems,
+        "warnings": STARTUP_WARNINGS,
+        "config": CONFIG.public_dict(),
+    }
+
+
+@app.get("/api/config")
+def configuration():
+    return {
+        **CONFIG.public_dict(),
+        "startup_warnings": STARTUP_WARNINGS,
+    }
 
 
 @app.get("/api/runs")
 def runs():
-    return {"runs": list_run_summaries(ARTIFACT_ROOT)}
+    try:
+        summaries = list_dashboard_summaries(
+            ARTIFACT_ROOT,
+            stale_after_seconds=CONFIG.stale_after_seconds,
+        )
+    except OSError as error:
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to scan artifact root {ARTIFACT_ROOT}: {error}",
+        ) from error
+    return {"runs": summaries}
 
 
 @app.get("/api/runs/{run_id}")
 def run_status(run_id: str):
     ref = _run(run_id)
-    return summarize_run(ref.path, ARTIFACT_ROOT)
+    return summarize_dashboard_run(
+        ref.path,
+        ARTIFACT_ROOT,
+        stale_after_seconds=CONFIG.stale_after_seconds,
+        detailed=True,
+    )
+
+
+@app.get("/api/runs/{run_id}/summary.json")
+def run_summary(run_id: str):
+    ref = _run(run_id)
+    summary = summarize_dashboard_run(
+        ref.path,
+        ARTIFACT_ROOT,
+        stale_after_seconds=CONFIG.stale_after_seconds,
+        detailed=True,
+    )
+    return JSONResponse(
+        content=summary,
+        headers={"Content-Disposition": 'attachment; filename="run-summary.json"'},
+    )
 
 
 @app.get("/api/runs/{run_id}/telemetry")
 def telemetry(run_id: str, limit: int = 2000):
     ref = _run(run_id)
     limit = max(1, min(limit, 20_000))
-    return {"records": load_training_records(ref.path, limit=limit)}
+    return {"records": load_dashboard_records(ref.path, limit=limit)}
 
 
 @app.get("/api/runs/{run_id}/logs")
@@ -99,7 +172,10 @@ async def stream_logs(run_id: str, request: Request):
             except FileNotFoundError:
                 pass
             except OSError as error:
-                yield f"event: monitor_error\ndata: {json.dumps({'message': str(error)})}\n\n"
+                yield (
+                    "event: monitor_error\n"
+                    f"data: {json.dumps({'message': str(error)})}\n\n"
+                )
             yield ": keepalive\n\n"
             await asyncio.sleep(1.0)
 
@@ -120,6 +196,8 @@ def index():
             "message": "Dashboard frontend is not built yet.",
             "build": "cd dashboard/frontend && npm install && npm run build",
             "api": "/api/runs",
+            "health": "/api/health",
+            "config": "/api/config",
         }
     )
 

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,0 +1,106 @@
+"""Shared dashboard configuration and startup validation."""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT_ROOT = REPO_ROOT / "logs" / "rsl_rl"
+DEFAULT_FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
+DEFAULT_STALE_AFTER_SECONDS = 90.0
+
+
+@dataclass(frozen=True)
+class DashboardConfig:
+    repo_root: Path
+    artifact_root: Path
+    frontend_dist: Path
+    stale_after_seconds: float
+
+    def public_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": str(self.repo_root),
+            "artifact_root": str(self.artifact_root),
+            "frontend_dist": str(self.frontend_dist),
+            "frontend_built": (self.frontend_dist / "index.html").is_file(),
+            "stale_after_seconds": self.stale_after_seconds,
+            "python_executable": sys.executable,
+            "uv_available": shutil.which("uv") is not None,
+            "nvidia_smi_available": shutil.which("nvidia-smi") is not None,
+        }
+
+
+def _positive_float(name: str, raw: str | None, default: float) -> float:
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError as error:
+        raise RuntimeError(f"{name} must be a number, got {raw!r}") from error
+    if value <= 0:
+        raise RuntimeError(f"{name} must be greater than zero, got {value}")
+    return value
+
+
+def load_config() -> DashboardConfig:
+    artifact_root = Path(
+        os.environ.get("ASCENTO_ARTIFACT_ROOT", str(DEFAULT_ARTIFACT_ROOT))
+    ).expanduser().resolve()
+    frontend_dist = Path(
+        os.environ.get("ASCENTO_DASHBOARD_DIST", str(DEFAULT_FRONTEND_DIST))
+    ).expanduser().resolve()
+    stale_after = _positive_float(
+        "ASCENTO_STALE_AFTER_SECONDS",
+        os.environ.get("ASCENTO_STALE_AFTER_SECONDS"),
+        DEFAULT_STALE_AFTER_SECONDS,
+    )
+    return DashboardConfig(
+        repo_root=REPO_ROOT,
+        artifact_root=artifact_root,
+        frontend_dist=frontend_dist,
+        stale_after_seconds=stale_after,
+    )
+
+
+def validate_startup(config: DashboardConfig, *, create_artifact_root: bool = True) -> list[str]:
+    """Validate paths early and return non-fatal startup warnings."""
+    warnings: list[str] = []
+
+    if config.artifact_root.exists() and not config.artifact_root.is_dir():
+        raise RuntimeError(
+            "Dashboard artifact root is not a directory: "
+            f"{config.artifact_root}. Set ASCENTO_ARTIFACT_ROOT to a directory."
+        )
+
+    if create_artifact_root:
+        try:
+            config.artifact_root.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            raise RuntimeError(
+                "Dashboard could not create the artifact root "
+                f"{config.artifact_root}: {error}. "
+                "Set ASCENTO_ARTIFACT_ROOT to a writable directory."
+            ) from error
+
+    if config.artifact_root.exists():
+        if not os.access(config.artifact_root, os.R_OK):
+            raise RuntimeError(f"Dashboard artifact root is not readable: {config.artifact_root}")
+        if not os.access(config.artifact_root, os.X_OK):
+            raise RuntimeError(f"Dashboard artifact root is not searchable: {config.artifact_root}")
+
+    if config.frontend_dist.exists() and not config.frontend_dist.is_dir():
+        raise RuntimeError(
+            "ASCENTO_DASHBOARD_DIST must point to a directory, got "
+            f"{config.frontend_dist}"
+        )
+    if not (config.frontend_dist / "index.html").is_file():
+        warnings.append(
+            "Dashboard frontend is not built. Run "
+            "`cd dashboard/frontend && npm install && npm run build`."
+        )
+
+    return warnings

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -10,55 +10,94 @@ import {
 } from 'recharts'
 
 const POLL_MS = 5000
-const METRIC_PRIORITY = [
-  'eval/episode_reward',
-  'training/total_loss',
-  'training/invalid_update',
-  'eval/avg_episode_length',
-  'training/policy_loss',
-  'training/v_loss',
-  'training/entropy_loss',
+const CANONICAL_CHARTS = [
+  { key: 'reward', label: 'Reward trend' },
+  { key: 'episode_length', label: 'Episode length trend' },
+  { key: 'ppo_loss', label: 'PPO / surrogate loss' },
+  { key: 'entropy', label: 'Entropy' },
+  { key: 'kl', label: 'KL divergence' },
+  { key: 'clip_fraction', label: 'Clip fraction' },
 ]
 
 function fmtNumber(value, digits = 1) {
-  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—'
+  if (value === null || value === undefined || !Number.isFinite(Number(value))) return '—'
   return Number(value).toLocaleString(undefined, { maximumFractionDigits: digits })
 }
 
 function fmtDuration(seconds) {
   if (seconds === null || seconds === undefined || !Number.isFinite(Number(seconds))) return '—'
   const total = Math.max(0, Math.round(Number(seconds)))
-  const hours = Math.floor(total / 3600)
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
   const minutes = Math.floor((total % 3600) / 60)
   const secs = total % 60
+  if (days) return `${days}d ${hours}h`
   if (hours) return `${hours}h ${minutes}m`
   if (minutes) return `${minutes}m ${secs}s`
   return `${secs}s`
+}
+
+function fmtDate(value) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return String(value)
+  return date.toLocaleString()
 }
 
 function StateBadge({ state }) {
   return <span className={`state-badge state-${state || 'unknown'}`}>{state || 'unknown'}</span>
 }
 
-function MetricChart({ records, metric }) {
+function ApiBadge({ health }) {
+  if (!health) return <span className="api-badge api-pending">API checking</span>
+  const label = health.ok ? 'API healthy' : 'API error'
+  return <span className={`api-badge ${health.ok ? 'api-ok' : 'api-bad'}`}>{label}</span>
+}
+
+function MetricChart({ records, metric, label }) {
   return (
     <section className="panel metric-panel">
-      <div className="panel-title">{metric}</div>
+      <div className="panel-title">{label}</div>
       <div className="chart-wrap">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={records} margin={{ top: 8, right: 14, left: -8, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
-            <XAxis dataKey="step" tickFormatter={(value) => `${fmtNumber(value / 1e6, 1)}M`} minTickGap={24} />
-            <YAxis width={58} tickFormatter={(value) => fmtNumber(value, 2)} domain={['auto', 'auto']} />
+            <XAxis dataKey="iteration" tickFormatter={(value) => fmtNumber(value, 0)} minTickGap={24} />
+            <YAxis width={58} tickFormatter={(value) => fmtNumber(value, 3)} domain={['auto', 'auto']} />
             <Tooltip
-              formatter={(value) => fmtNumber(value, 5)}
-              labelFormatter={(step) => `${fmtNumber(step, 0)} steps`}
+              formatter={(value) => fmtNumber(value, 6)}
+              labelFormatter={(iteration) => `Iteration ${fmtNumber(iteration, 0)}`}
             />
-            <Line type="monotone" dataKey={metric} dot={false} isAnimationActive={false} strokeWidth={2} connectNulls />
+            <Line
+              type="monotone"
+              dataKey={metric}
+              dot={false}
+              isAnimationActive={false}
+              strokeWidth={2}
+              connectNulls
+            />
           </LineChart>
         </ResponsiveContainer>
       </div>
     </section>
+  )
+}
+
+function HealthMetric({ label, value, suffix = '', warning = false }) {
+  return (
+    <div className={`health-metric ${warning ? 'health-warning' : ''}`}>
+      <span>{label}</span>
+      <strong>{value}{value !== '—' ? suffix : ''}</strong>
+    </div>
+  )
+}
+
+function MetadataRow({ label, children, mono = false }) {
+  return (
+    <div className="metadata-row">
+      <dt>{label}</dt>
+      <dd className={mono ? 'mono' : ''}>{children ?? '—'}</dd>
+    </div>
   )
 }
 
@@ -68,8 +107,10 @@ function App() {
   const [detail, setDetail] = useState(null)
   const [telemetry, setTelemetry] = useState([])
   const [logs, setLogs] = useState([])
+  const [health, setHealth] = useState(null)
   const [apiError, setApiError] = useState('')
   const [autoScroll, setAutoScroll] = useState(true)
+  const [copyState, setCopyState] = useState('')
   const terminalRef = useRef(null)
 
   async function fetchJson(url, options) {
@@ -81,11 +122,24 @@ function App() {
     return response.json()
   }
 
+  async function refreshHealth() {
+    try {
+      const data = await fetchJson('/api/health')
+      setHealth(data)
+    } catch (error) {
+      setHealth({ ok: false, problems: [error.message] })
+    }
+  }
+
   async function refreshRuns() {
     try {
       const data = await fetchJson('/api/runs')
-      setRuns(data.runs || [])
-      setSelectedId((current) => current || data.runs?.[0]?.id || null)
+      const nextRuns = data.runs || []
+      setRuns(nextRuns)
+      setSelectedId((current) => {
+        if (current && nextRuns.some((run) => run.id === current)) return current
+        return nextRuns[0]?.id || null
+      })
       setApiError('')
     } catch (error) {
       setApiError(error.message)
@@ -93,7 +147,11 @@ function App() {
   }
 
   async function refreshSelected(id) {
-    if (!id) return
+    if (!id) {
+      setDetail(null)
+      setTelemetry([])
+      return
+    }
     try {
       const [run, points] = await Promise.all([
         fetchJson(`/api/runs/${id}`),
@@ -108,13 +166,21 @@ function App() {
   }
 
   useEffect(() => {
+    refreshHealth()
     refreshRuns()
-    const timer = setInterval(refreshRuns, POLL_MS)
+    const timer = setInterval(() => {
+      refreshHealth()
+      refreshRuns()
+    }, POLL_MS)
     return () => clearInterval(timer)
   }, [])
 
   useEffect(() => {
-    if (!selectedId) return undefined
+    if (!selectedId) {
+      setDetail(null)
+      return undefined
+    }
+    setCopyState('')
     refreshSelected(selectedId)
     const timer = setInterval(() => refreshSelected(selectedId), POLL_MS)
     return () => clearInterval(timer)
@@ -151,20 +217,49 @@ function App() {
   }, [logs, autoScroll])
 
   const chartRecords = useMemo(
-    () => telemetry.map((record) => ({ step: record.completed_steps, ...(record.metrics || {}) })),
+    () => telemetry.map((record) => ({
+      iteration: record.iteration ?? record.completed_steps,
+      ...(record.metrics || {}),
+      ...(record.canonical_metrics || {}),
+    })),
     [telemetry],
   )
 
-  const metricKeys = useMemo(() => {
-    const keys = [...new Set(telemetry.flatMap((record) => Object.keys(record.metrics || {})))]
-    const preferred = METRIC_PRIORITY.filter((key) => keys.includes(key))
-    const fallback = keys.filter((key) => !preferred.includes(key) && /reward|episode|loss|entropy|eval|surviv|fall/i.test(key))
-    return [...preferred, ...fallback, ...keys.filter((key) => !preferred.includes(key) && !fallback.includes(key))].slice(0, 4)
-  }, [telemetry])
+  const availableCharts = useMemo(
+    () => CANONICAL_CHARTS.filter(({ key }) => (
+      chartRecords.some((record) => Number.isFinite(Number(record[key])))
+    )),
+    [chartRecords],
+  )
 
   const progress = detail?.telemetry || {}
+  const canonical = detail?.training_health?.latest || progress.canonical_metrics || {}
   const percent = Number(progress.percent_complete || 0)
-  const stage = progress.stage || detail?.status?.stage || detail?.stage
+  const currentIteration = progress.iteration ?? progress.completed_steps
+  const totalIterations = progress.total_iterations ?? progress.total_steps
+  const displayState = detail?.stale ? 'stale' : detail?.state
+  const runInfo = detail?.run_info || {}
+  const processAlive = detail?.process?.alive
+  const gpus = detail?.system?.gpus || []
+
+  async function copyRunInformation() {
+    if (!detail) return
+    const payload = {
+      run: detail.name,
+      state: detail.state,
+      stale: detail.stale,
+      freshness_seconds: detail.freshness_seconds,
+      run_info: runInfo,
+      training_health: detail.training_health,
+    }
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(payload, null, 2))
+      setCopyState('Copied')
+    } catch (_) {
+      setCopyState('Copy failed')
+    }
+  }
+
   return (
     <main className="app-shell">
       <header className="topbar">
@@ -173,8 +268,10 @@ function App() {
           <h1>Training Monitor</h1>
         </div>
         <div className="topbar-actions">
-          {detail && <StateBadge state={detail.state} />}
+          <ApiBadge health={health} />
+          {detail && <StateBadge state={displayState} />}
           <select value={selectedId || ''} onChange={(event) => setSelectedId(event.target.value)}>
+            {runs.length === 0 && <option value="">No runs found</option>}
             {runs.map((run) => (
               <option key={run.id} value={run.id}>{run.name}</option>
             ))}
@@ -183,50 +280,208 @@ function App() {
       </header>
 
       {apiError && <div className="api-error">{apiError}</div>}
+      {health?.problems?.length > 0 && (
+        <div className="api-error">
+          <strong>Dashboard health check failed.</strong>
+          <ul>{health.problems.map((problem) => <li key={problem}>{problem}</li>)}</ul>
+        </div>
+      )}
+      {detail?.stale && (
+        <div className="stale-warning">
+          Telemetry is stale: no update for {fmtDuration(detail.freshness_seconds)}.
+          The run is still marked {detail.state}.
+        </div>
+      )}
+      {detail?.training_health?.non_finite_updates > 0 && (
+        <div className="api-error">
+          NaN/Inf detected in {detail.training_health.non_finite_updates} telemetry update(s):
+          {' '}{detail.training_health.non_finite_metrics.join(', ') || 'unknown metric'}.
+        </div>
+      )}
       {!detail && !apiError && <div className="empty-state">No training artifacts found yet.</div>}
 
       {detail && (
         <>
           <section className="stats-grid">
-            <div className="stat-card"><span>Stage</span><strong>{stage}</strong></div>
+            <div className="stat-card"><span>Stage</span><strong>{detail.stage || '—'}</strong></div>
             <div className="stat-card"><span>Progress</span><strong>{fmtNumber(percent, 2)}%</strong></div>
-            <div className="stat-card"><span>Steps</span><strong>{fmtNumber(progress.completed_steps, 0)}</strong><small>/ {fmtNumber(progress.total_steps, 0)}</small></div>
-            <div className="stat-card"><span>Throughput</span><strong>{fmtNumber(progress.steps_per_second, 0)}</strong><small>steps/s</small></div>
+            <div className="stat-card">
+              <span>Iteration</span>
+              <strong>{fmtNumber(currentIteration, 0)}</strong>
+              <small>/ {fmtNumber(totalIterations, 0)}</small>
+            </div>
+            <div className="stat-card">
+              <span>Freshness</span>
+              <strong>{fmtDuration(detail.freshness_seconds)}</strong>
+              <small>since last telemetry</small>
+            </div>
+            <div className="stat-card">
+              <span>Throughput</span>
+              <strong>{fmtNumber(progress.steps_per_second ?? canonical.throughput, 0)}</strong>
+              <small>env steps/s</small>
+            </div>
             <div className="stat-card"><span>Elapsed</span><strong>{fmtDuration(progress.elapsed_seconds)}</strong></div>
             <div className="stat-card"><span>ETA</span><strong>{fmtDuration(progress.eta_seconds)}</strong></div>
+            <div className="stat-card">
+              <span>Process</span>
+              <strong>{processAlive === true ? 'alive' : processAlive === false ? 'stopped' : 'unknown'}</strong>
+              <small>{detail.process?.pid ? `PID ${detail.process.pid}` : 'no PID recorded'}</small>
+            </div>
           </section>
 
           <section className="panel progress-panel">
-            <div className="progress-heading"><span>Training progress</span><span>{fmtNumber(percent, 2)}%</span></div>
-            <div className="progress-track"><div className="progress-fill" style={{ width: `${Math.min(100, Math.max(0, percent))}%` }} /></div>
+            <div className="progress-heading">
+              <span>Training progress</span>
+              <span>{fmtNumber(percent, 2)}%</span>
+            </div>
+            <div className="progress-track">
+              <div className="progress-fill" style={{ width: `${Math.min(100, Math.max(0, percent))}%` }} />
+            </div>
           </section>
 
           <section className="content-grid">
             <div className="charts-grid">
-              {metricKeys.length ? metricKeys.map((metric) => (
-                <MetricChart key={metric} records={chartRecords} metric={metric} />
-              )) : <section className="panel empty-panel">Waiting for metric telemetry…</section>}
+              {availableCharts.length ? availableCharts.map(({ key, label }) => (
+                <MetricChart key={key} records={chartRecords} metric={key} label={label} />
+              )) : <section className="panel empty-panel">Waiting for reward/PPO telemetry…</section>}
             </div>
 
             <aside className="side-column">
               <section className="panel">
-                <div className="panel-title">Motion capture</div>
-                <div className="empty-panel">Use <code>capture-motion</code> for RecorderManager exports.</div>
+                <div className="panel-title">Training health</div>
+                <div className="health-grid">
+                  <HealthMetric label="Reward" value={fmtNumber(canonical.reward, 4)} />
+                  <HealthMetric label="Episode length" value={fmtNumber(canonical.episode_length, 2)} />
+                  <HealthMetric label="PPO loss" value={fmtNumber(canonical.ppo_loss, 6)} />
+                  <HealthMetric label="Entropy" value={fmtNumber(canonical.entropy, 6)} />
+                  <HealthMetric label="KL" value={fmtNumber(canonical.kl, 6)} />
+                  <HealthMetric label="Clip fraction" value={fmtNumber(canonical.clip_fraction, 5)} />
+                  <HealthMetric
+                    label="Invalid updates"
+                    value={fmtNumber(detail.training_health?.invalid_updates, 0)}
+                    warning={(detail.training_health?.invalid_updates || 0) > 0}
+                  />
+                  <HealthMetric
+                    label="NaN / Inf updates"
+                    value={fmtNumber(detail.training_health?.non_finite_updates, 0)}
+                    warning={(detail.training_health?.non_finite_updates || 0) > 0}
+                  />
+                </div>
+              </section>
+
+              <section className="panel">
+                <div className="panel-title">GPU / process</div>
+                <div className="gpu-summary">
+                  <div><span>Process</span><strong>{processAlive === true ? 'alive' : processAlive === false ? 'stopped' : 'unknown'}</strong></div>
+                  <div><span>PID</span><strong>{detail.process?.pid || '—'}</strong></div>
+                  <div><span>Process GPU memory</span><strong>{fmtNumber(detail.system?.process_gpu_memory_mb, 0)} MB</strong></div>
+                </div>
+                {gpus.length ? gpus.map((gpu) => (
+                  <div className="gpu-card" key={gpu.uuid || gpu.index}>
+                    <div className="gpu-name">GPU {gpu.index}: {gpu.name}</div>
+                    <div className="gpu-values">
+                      <span>{fmtNumber(gpu.utilization_percent, 0)}% util</span>
+                      <span>{fmtNumber(gpu.memory_used_mb, 0)} / {fmtNumber(gpu.memory_total_mb, 0)} MB</span>
+                      <span>{fmtNumber(gpu.temperature_c, 0)} °C</span>
+                    </div>
+                  </div>
+                )) : (
+                  <div className="empty-panel">
+                    {detail.system?.available === false ? 'nvidia-smi unavailable.' : 'No GPU telemetry available.'}
+                  </div>
+                )}
               </section>
 
               <section className={`panel error-panel ${detail.errors?.length ? 'has-errors' : ''}`}>
                 <div className="panel-title">Errors</div>
-                {detail.errors?.length ? <pre>{detail.errors.join('\n')}</pre> : <div className="ok-message">No recent errors detected.</div>}
+                {detail.errors?.length
+                  ? <pre>{detail.errors.join('\n')}</pre>
+                  : <div className="ok-message">No recent errors detected.</div>}
               </section>
             </aside>
+          </section>
+
+          <section className="panel metadata-panel">
+            <div className="panel-title-row">
+              <div>
+                <div className="panel-title">Run information</div>
+                <div className="panel-subtitle">Reproducibility metadata captured by dashboard.launch and the run artifacts.</div>
+              </div>
+              <div className="button-row">
+                <button onClick={copyRunInformation}>{copyState || 'Copy run information'}</button>
+                <a
+                  className="button-link"
+                  href={`/api/runs/${selectedId}/summary.json`}
+                  download="run-summary.json"
+                >
+                  Download run-summary.json
+                </a>
+              </div>
+            </div>
+            <dl className="metadata-grid">
+              <MetadataRow label="Git commit" mono>{runInfo.git_commit}</MetadataRow>
+              <MetadataRow label="Git branch">{runInfo.git_branch}</MetadataRow>
+              <MetadataRow label="Task">{runInfo.task}</MetadataRow>
+              <MetadataRow label="Stage">{runInfo.stage || detail.stage}</MetadataRow>
+              <MetadataRow label="Seed">{runInfo.seed}</MetadataRow>
+              <MetadataRow label="Device">{runInfo.device}</MetadataRow>
+              <MetadataRow label="Simulation timestep">{runInfo.simulation_timestep}</MetadataRow>
+              <MetadataRow label="Checkpoint / model" mono>{runInfo.checkpoint_path || runInfo.model_path}</MetadataRow>
+              <MetadataRow label="Started">{fmtDate(runInfo.started_at)}</MetadataRow>
+              <MetadataRow label="Finished">{fmtDate(runInfo.finished_at)}</MetadataRow>
+              <MetadataRow label="Exit code">{runInfo.exit_code}</MetadataRow>
+              <MetadataRow label="Command" mono>
+                {Array.isArray(runInfo.command) ? runInfo.command.join(' ') : runInfo.command}
+              </MetadataRow>
+            </dl>
+            <div className="config-files">
+              <div className="panel-title">Configuration files</div>
+              {runInfo.configuration_files?.length ? (
+                <ul>
+                  {runInfo.configuration_files.map((file) => (
+                    <li key={file.path}><code>{file.path}</code> <span>{fmtNumber(file.size_bytes, 0)} bytes</span></li>
+                  ))}
+                </ul>
+              ) : <div className="empty-panel">No run configuration files found.</div>}
+            </div>
+          </section>
+
+          <section className="panel config-panel">
+            <div className="panel-title-row">
+              <div>
+                <div className="panel-title">Dashboard configuration</div>
+                <div className="panel-subtitle">Active server configuration; useful for diagnosing artifact discovery.</div>
+              </div>
+              <ApiBadge health={health} />
+            </div>
+            <dl className="metadata-grid compact">
+              <MetadataRow label="Artifact root" mono>{health?.config?.artifact_root}</MetadataRow>
+              <MetadataRow label="Frontend dist" mono>{health?.config?.frontend_dist}</MetadataRow>
+              <MetadataRow label="Frontend built">{health?.config?.frontend_built ? 'yes' : 'no'}</MetadataRow>
+              <MetadataRow label="Stale threshold">{health?.config?.stale_after_seconds ? `${health.config.stale_after_seconds}s` : '—'}</MetadataRow>
+              <MetadataRow label="Python" mono>{health?.config?.python_executable}</MetadataRow>
+              <MetadataRow label="Detected runs">{health?.run_count}</MetadataRow>
+            </dl>
+            {health?.warnings?.length > 0 && (
+              <ul className="warning-list">{health.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul>
+            )}
           </section>
 
           <section className="panel terminal-panel">
             <div className="panel-title-row">
               <div className="panel-title">Console output</div>
-              <label className="checkbox"><input type="checkbox" checked={autoScroll} onChange={(event) => setAutoScroll(event.target.checked)} /> auto-scroll</label>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={autoScroll}
+                  onChange={(event) => setAutoScroll(event.target.checked)}
+                />
+                auto-scroll
+              </label>
             </div>
-            <pre ref={terminalRef} className="terminal">{logs.length ? logs.join('\n') : 'No captured training.log for this run.'}</pre>
+            <pre ref={terminalRef} className="terminal">
+              {logs.length ? logs.join('\n') : 'No captured training.log for this run.'}
+            </pre>
           </section>
         </>
       )}

--- a/dashboard/frontend/src/styles.css
+++ b/dashboard/frontend/src/styles.css
@@ -9,78 +9,189 @@
 body { margin: 0; min-width: 320px; min-height: 100vh; background: radial-gradient(circle at top, #121a2c 0, #080b12 42%); }
 button, select, input { font: inherit; }
 button { cursor: pointer; }
+code, .mono { font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace; }
 
-.app-shell { width: min(1500px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
+.app-shell { width: min(1550px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 48px; }
 .topbar { display: flex; justify-content: space-between; gap: 24px; align-items: center; margin-bottom: 24px; }
 .eyebrow { color: #86a8ff; letter-spacing: .16em; font-size: .72rem; font-weight: 800; }
 h1 { margin: 5px 0 0; font-size: clamp(1.7rem, 3vw, 2.5rem); }
-.topbar-actions { display: flex; align-items: center; gap: 12px; }
-select, button { border: 1px solid #2b3853; border-radius: 10px; background: #121827; color: #e8edf7; padding: 9px 12px; }
-button:hover:not(:disabled), select:hover { border-color: #5d7bbb; }
+.topbar-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+select, button, .button-link {
+  border: 1px solid #2b3853;
+  border-radius: 10px;
+  background: #121827;
+  color: #e8edf7;
+  padding: 9px 12px;
+}
+.button-link { display: inline-flex; align-items: center; text-decoration: none; font-size: .85rem; }
+button:hover:not(:disabled), select:hover, .button-link:hover { border-color: #5d7bbb; }
 button:disabled { opacity: .5; cursor: default; }
+.button-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
-.state-badge { border-radius: 999px; padding: 6px 10px; text-transform: uppercase; font-size: .72rem; font-weight: 800; letter-spacing: .08em; border: 1px solid currentColor; }
+.state-badge, .api-badge {
+  border-radius: 999px;
+  padding: 6px 10px;
+  text-transform: uppercase;
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .07em;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
 .state-running { color: #62d995; }
 .state-finished { color: #7bb7ff; }
 .state-error, .state-cancelled { color: #ff7d8f; }
 .state-starting, .state-unknown { color: #d0ae68; }
+.state-stale { color: #ffbd66; }
+.api-ok { color: #62d995; }
+.api-bad { color: #ff7d8f; }
+.api-pending { color: #9aa7bd; }
 
-.api-error { border: 1px solid #7d3441; background: #251117; color: #ffb8c1; padding: 12px 14px; border-radius: 12px; margin-bottom: 16px; }
+.api-error, .stale-warning {
+  border: 1px solid #7d3441;
+  background: #251117;
+  color: #ffb8c1;
+  padding: 12px 14px;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+.api-error strong { display: block; margin-bottom: 4px; }
+.api-error ul, .warning-list { margin: 8px 0 0; padding-left: 20px; }
+.stale-warning { border-color: #795a2e; background: #241b0d; color: #ffd293; }
 .empty-state { padding: 60px 20px; text-align: center; color: #8895aa; }
 
-.stats-grid { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 12px; margin-bottom: 12px; }
-.stat-card, .panel { border: 1px solid #202a3d; background: rgba(15, 21, 34, .92); border-radius: 14px; box-shadow: 0 12px 35px rgba(0,0,0,.16); }
-.stat-card { padding: 16px; min-width: 0; }
-.stat-card span, .stat-card small { display: block; color: #8390a5; font-size: .75rem; }
-.stat-card strong { display: block; margin-top: 6px; font-size: 1.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.stat-card, .panel {
+  border: 1px solid #202a3d;
+  background: rgba(15, 21, 34, .92);
+  border-radius: 14px;
+  box-shadow: 0 12px 35px rgba(0,0,0,.16);
+}
+.stat-card { padding: 14px; min-width: 0; }
+.stat-card span, .stat-card small { display: block; color: #8390a5; font-size: .72rem; }
+.stat-card strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.15rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .stat-card small { margin-top: 3px; }
 
 .panel { padding: 16px; }
 .panel-title { font-size: .82rem; color: #aab5c7; font-weight: 700; overflow-wrap: anywhere; }
-.panel-title-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.panel-subtitle { margin-top: 4px; color: #6f7c91; font-size: .74rem; line-height: 1.4; }
+.panel-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
 .progress-panel { margin-bottom: 12px; }
 .progress-heading { display: flex; justify-content: space-between; color: #aab5c7; margin-bottom: 10px; font-size: .82rem; }
 .progress-track { height: 10px; border-radius: 999px; background: #20293a; overflow: hidden; }
 .progress-fill { height: 100%; border-radius: inherit; background: linear-gradient(90deg, #7096ff, #77dfbf); transition: width .35s ease; }
 
-.content-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, .85fr); gap: 12px; }
-.charts-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
-.metric-panel { min-height: 280px; }
-.chart-wrap { height: 230px; margin-top: 10px; }
+.content-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(330px, .82fr); gap: 12px; }
+.charts-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-content: start; }
+.metric-panel { min-height: 270px; }
+.chart-wrap { height: 220px; margin-top: 10px; }
 .recharts-cartesian-grid line { stroke: #283246; }
 .recharts-text { fill: #7f8ca1; font-size: 11px; }
 .recharts-default-tooltip { background: #0c111d !important; border: 1px solid #33405a !important; border-radius: 8px; }
 
 .side-column { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
-.render-panel img { width: 100%; display: block; border-radius: 10px; border: 1px solid #252f43; background: #05070a; }
-.render-meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
-.render-meta div { background: #0c111c; padding: 8px 9px; border-radius: 8px; min-width: 0; }
-.render-meta span, .render-meta strong { display: block; overflow: hidden; text-overflow: ellipsis; }
-.render-meta span { color: #738198; font-size: .68rem; }
-.render-meta strong { font-size: .85rem; margin-top: 3px; }
+.health-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+.health-metric { border: 1px solid #202a3d; border-radius: 9px; background: #0c111c; padding: 9px; min-width: 0; }
+.health-metric span { display: block; color: #738198; font-size: .68rem; }
+.health-metric strong { display: block; margin-top: 4px; overflow: hidden; text-overflow: ellipsis; font-size: .9rem; }
+.health-warning { border-color: #74404a; background: #211116; }
+.health-warning strong { color: #ff9eaa; }
+
+.gpu-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+.gpu-summary div { background: #0c111c; border-radius: 8px; padding: 8px; min-width: 0; }
+.gpu-summary span, .gpu-summary strong { display: block; overflow: hidden; text-overflow: ellipsis; }
+.gpu-summary span { color: #738198; font-size: .66rem; }
+.gpu-summary strong { margin-top: 4px; font-size: .82rem; }
+.gpu-card { margin-top: 9px; border: 1px solid #202a3d; border-radius: 9px; padding: 9px; background: #0a0f19; }
+.gpu-name { color: #b8c3d4; font-size: .78rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.gpu-values { margin-top: 6px; display: flex; gap: 10px; flex-wrap: wrap; color: #7f8ca1; font-size: .72rem; }
+
 .error-panel { flex: 1; }
 .error-panel.has-errors { border-color: #70323c; }
 .error-panel pre { max-height: 250px; overflow: auto; white-space: pre-wrap; color: #ffabb5; font-size: .75rem; }
 .ok-message, .empty-panel { color: #7f8ca1; padding: 18px 0; }
 
-.terminal-panel { margin-top: 12px; }
+.metadata-panel, .config-panel, .terminal-panel { margin-top: 12px; }
+.metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  background: #202a3d;
+  border: 1px solid #202a3d;
+  border-radius: 10px;
+  overflow: hidden;
+}
+.metadata-grid.compact { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.metadata-row { margin: 0; padding: 10px; background: #0c111c; min-width: 0; }
+.metadata-row dt { color: #738198; font-size: .66rem; margin-bottom: 4px; }
+.metadata-row dd { margin: 0; color: #d7dfed; font-size: .8rem; overflow-wrap: anywhere; }
+.config-files { margin-top: 14px; }
+.config-files ul { list-style: none; padding: 0; margin: 8px 0 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+.config-files li { display: flex; justify-content: space-between; gap: 10px; border: 1px solid #202a3d; background: #0c111c; padding: 8px 9px; border-radius: 8px; min-width: 0; font-size: .72rem; }
+.config-files li code { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.config-files li span { color: #6f7c91; white-space: nowrap; }
+
+.warning-list { color: #ffd293; font-size: .76rem; }
+
 .checkbox { color: #8d9ab0; font-size: .78rem; display: flex; gap: 6px; align-items: center; }
-.terminal { margin: 0; height: 330px; overflow: auto; background: #05070b; border: 1px solid #202a3a; border-radius: 10px; padding: 14px; color: #c6d2e6; font: 12px/1.55 "Cascadia Code", "SFMono-Regular", Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+.terminal {
+  margin: 0;
+  height: 330px;
+  overflow: auto;
+  background: #05070b;
+  border: 1px solid #202a3a;
+  border-radius: 10px;
+  padding: 14px;
+  color: #c6d2e6;
+  font: 12px/1.55 "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 1320px) {
+  .stats-grid { grid-template-columns: repeat(4, 1fr); }
+}
 
 @media (max-width: 1050px) {
-  .stats-grid { grid-template-columns: repeat(3, 1fr); }
   .content-grid { grid-template-columns: 1fr; }
   .side-column { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .error-panel { grid-column: 1 / -1; }
+  .metadata-grid, .metadata-grid.compact { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 700px) {
-  .app-shell { width: min(100% - 20px, 1500px); padding-top: 18px; }
+  .app-shell { width: min(100% - 20px, 1550px); padding-top: 18px; }
   .topbar { align-items: flex-start; flex-direction: column; }
-  .topbar-actions { width: 100%; }
+  .topbar-actions { width: 100%; justify-content: flex-start; }
   .topbar-actions select { flex: 1; min-width: 0; }
   .stats-grid { grid-template-columns: repeat(2, 1fr); }
-  .charts-grid, .side-column { grid-template-columns: 1fr; }
+  .charts-grid, .side-column, .metadata-grid, .metadata-grid.compact { grid-template-columns: 1fr; }
+  .error-panel { grid-column: auto; }
   .metric-panel { min-height: 250px; }
   .chart-wrap { height: 205px; }
+  .gpu-summary { grid-template-columns: 1fr; }
+  .config-files ul { grid-template-columns: 1fr; }
+  .panel-title-row { align-items: flex-start; flex-direction: column; }
+  .button-row { width: 100%; }
+  .button-row button, .button-row .button-link { flex: 1; justify-content: center; }
   .terminal { height: 420px; }
 }

--- a/dashboard/health.py
+++ b/dashboard/health.py
@@ -1,0 +1,433 @@
+"""Training health, process/GPU status, and reproducibility metadata for the dashboard."""
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from dashboard import monitor
+
+ALIASES: dict[str, tuple[str, ...]] = {
+    "reward": ("Train/mean_reward", "train/mean_reward", "eval/episode_reward", "Episode/reward", "episode_reward"),
+    "episode_length": ("Train/mean_episode_length", "train/mean_episode_length", "eval/avg_episode_length", "Episode/length", "episode_length"),
+    "ppo_loss": ("Loss/surrogate", "loss/surrogate", "training/policy_loss", "training/total_loss", "ppo_loss"),
+    "value_loss": ("Loss/value_function", "loss/value_function", "training/v_loss", "value_loss"),
+    "entropy": ("Loss/entropy", "loss/entropy", "Policy/entropy", "training/entropy", "training/entropy_loss", "entropy"),
+    "kl": ("Loss/kl", "loss/kl", "Policy/kl", "training/kl", "training/approx_kl", "approx_kl", "kl"),
+    "clip_fraction": ("Policy/clip_fraction", "Loss/clip_fraction", "training/clip_fraction", "clip_fraction"),
+    "invalid_update": ("training/invalid_update", "Train/invalid_update", "invalid_update"),
+    "throughput": ("Perf/total_fps", "perf/total_fps", "training/fps", "steps_per_second"),
+}
+CHECKPOINT_RE = re.compile(r"(?:model|checkpoint)[_-]?(\d+)", re.IGNORECASE)
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _finite(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def canonical_metrics(metrics: dict[str, Any]) -> dict[str, float | int | None]:
+    result: dict[str, float | int | None] = {}
+    for canonical, aliases in ALIASES.items():
+        result[canonical] = None
+        for alias in aliases:
+            value = metrics.get(alias)
+            if isinstance(value, bool):
+                result[canonical] = int(value)
+                break
+            if _finite(value):
+                result[canonical] = value
+                break
+    return result
+
+
+def _training_limit(run_dir: Path) -> int | None:
+    path = run_dir / "params" / "agent.yaml"
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r"^\s*max_iterations:\s*(\d+)\s*$", contents, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def decorate_records(records: list[dict[str, Any]], run_dir: Path) -> list[dict[str, Any]]:
+    """Return JSON-safe telemetry with canonical PPO metrics and iteration-rate ETA."""
+    decorated: list[dict[str, Any]] = []
+    total = _training_limit(run_dir)
+    for source in records:
+        record = dict(source)
+        raw_metrics = source.get("metrics") if isinstance(source.get("metrics"), dict) else {}
+        safe_metrics: dict[str, Any] = {}
+        non_finite: list[str] = []
+        for key, value in raw_metrics.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool) and not math.isfinite(float(value)):
+                safe_metrics[str(key)] = None
+                non_finite.append(str(key))
+            else:
+                safe_metrics[str(key)] = value
+        canonical = canonical_metrics(safe_metrics)
+        if canonical["invalid_update"] is None and non_finite:
+            canonical["invalid_update"] = 1
+        record["metrics"] = safe_metrics
+        record["canonical_metrics"] = canonical
+        record["non_finite_metrics"] = non_finite
+        record["has_non_finite"] = bool(non_finite)
+        iteration = record.get("iteration", record.get("completed_steps"))
+        if _finite(iteration):
+            record["iteration"] = int(iteration)
+        configured_total = record.get("total_iterations", record.get("total_steps", total))
+        if _finite(configured_total):
+            configured_total = int(configured_total)
+            record["total_iterations"] = configured_total
+            record["total_steps"] = configured_total
+            if _finite(iteration):
+                record["percent_complete"] = min(100.0, 100.0 * float(iteration) / max(configured_total, 1))
+        throughput = canonical.get("throughput")
+        if _finite(throughput) and float(throughput) > 0:
+            record["steps_per_second"] = float(throughput)
+        decorated.append(record)
+
+    if not decorated:
+        return decorated
+    first_wall = decorated[0].get("wall_time")
+    for index, record in enumerate(decorated):
+        wall = record.get("wall_time")
+        if _finite(first_wall) and _finite(wall):
+            record["elapsed_seconds"] = max(0.0, float(wall) - float(first_wall))
+        iteration = record.get("iteration")
+        total_iterations = record.get("total_iterations")
+        if not (_finite(iteration) and _finite(total_iterations)):
+            continue
+        if float(iteration) >= float(total_iterations):
+            record["eta_seconds"] = 0.0
+            continue
+        start = decorated[max(0, index - 20)]
+        start_iteration = start.get("iteration")
+        start_wall = start.get("wall_time")
+        if not (_finite(start_iteration) and _finite(start_wall) and _finite(wall)):
+            continue
+        delta_i = float(iteration) - float(start_iteration)
+        delta_t = float(wall) - float(start_wall)
+        if delta_i > 0 and delta_t > 0:
+            rate = delta_i / delta_t
+            record["iterations_per_second"] = rate
+            record["eta_seconds"] = max(0.0, (float(total_iterations) - float(iteration)) / rate)
+    return decorated
+
+
+def load_dashboard_records(run_dir: Path, limit: int | None = 2000) -> list[dict[str, Any]]:
+    # Load enough recent history to compute a stable rolling iteration rate.
+    raw_limit = None if limit is None else max(limit, 32)
+    records = decorate_records(monitor.load_training_records(run_dir, limit=raw_limit), run_dir)
+    return records[-limit:] if limit is not None else records
+
+
+def run_status_path(run_dir: Path, root: Path) -> Path:
+    for directory in (run_dir, *run_dir.parents):
+        if not _inside(directory, root):
+            break
+        candidate = directory / "run_status.json"
+        if candidate.is_file():
+            return candidate
+    return run_dir / "run_status.json"
+
+
+def _has_training_signal(path: Path) -> bool:
+    if (path / "telemetry.jsonl").is_file() or (path / "training_manifest.json").is_file():
+        return True
+    if (path / "params" / "agent.yaml").is_file():
+        return True
+    if any(path.glob("events.out.tfevents.*")) or any(path.glob("model_*.pt")):
+        return True
+    return False
+
+
+def discover_dashboard_runs(root: Path) -> list[monitor.RunRef]:
+    refs = monitor.discover_runs(root)
+    paths = {ref.path.resolve() for ref in refs}
+    filtered: list[monitor.RunRef] = []
+    for ref in refs:
+        path = ref.path.resolve()
+        launcher_only = (path / "run_status.json").is_file() and not _has_training_signal(path)
+        has_nested_signal = any(other != path and _inside(other, path) and _has_training_signal(other) for other in paths)
+        if launcher_only and has_nested_signal:
+            continue
+        filtered.append(ref)
+    return filtered
+
+
+def resolve_dashboard_run(root: Path, run_id: str) -> monitor.RunRef:
+    for ref in discover_dashboard_runs(root):
+        if ref.id == run_id:
+            return ref
+    raise KeyError(run_id)
+
+
+def process_status(pid: Any) -> dict[str, Any]:
+    if not isinstance(pid, int) or pid <= 0:
+        return {"pid": None, "alive": None}
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        alive = False
+    except PermissionError:
+        alive = True
+    except OSError:
+        alive = None
+    else:
+        alive = True
+    return {"pid": pid, "alive": alive}
+
+
+def gpu_snapshot(pid: int | None = None) -> dict[str, Any]:
+    executable = shutil.which("nvidia-smi")
+    if executable is None:
+        return {"available": False, "gpus": [], "process_gpu_memory_mb": None}
+    try:
+        result = subprocess.run(
+            [executable, "--query-gpu=index,name,uuid,utilization.gpu,memory.used,memory.total,temperature.gpu", "--format=csv,noheader,nounits"],
+            check=True, capture_output=True, text=True, timeout=2.0,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        return {"available": False, "gpus": [], "process_gpu_memory_mb": None, "error": str(error)}
+    gpus: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 7:
+            continue
+        try:
+            gpus.append({
+                "index": int(parts[0]), "name": parts[1], "uuid": parts[2],
+                "utilization_percent": float(parts[3]), "memory_used_mb": float(parts[4]),
+                "memory_total_mb": float(parts[5]), "temperature_c": float(parts[6]),
+            })
+        except ValueError:
+            continue
+    process_memory: float | None = None
+    if isinstance(pid, int) and pid > 0:
+        try:
+            result = subprocess.run(
+                [executable, "--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"],
+                check=True, capture_output=True, text=True, timeout=2.0,
+            )
+            for line in result.stdout.splitlines():
+                parts = [part.strip() for part in line.split(",")]
+                if len(parts) == 2 and parts[0].isdigit() and int(parts[0]) == pid:
+                    try:
+                        process_memory = (process_memory or 0.0) + float(parts[1])
+                    except ValueError:
+                        pass
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return {"available": True, "gpus": gpus, "process_gpu_memory_mb": process_memory}
+
+
+def _yaml_scalar(path: Path, key: str) -> str | None:
+    try:
+        contents = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    match = re.search(rf"^\s*{re.escape(key)}:\s*([^#]+?)\s*$", contents, re.MULTILINE)
+    return match.group(1).strip().strip("\"'") if match else None
+
+
+def _yaml_nested_scalar(path: Path, parent: str, key: str) -> str | None:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    parent_indent: int | None = None
+    parent_re = re.compile(rf"^(\s*){re.escape(parent)}:\s*(?:#.*)?$")
+    key_re = re.compile(rf"^(\s*){re.escape(key)}:\s*([^#]+?)\s*$")
+    for line in lines:
+        if parent_indent is None:
+            match = parent_re.match(line)
+            if match:
+                parent_indent = len(match.group(1))
+            continue
+        indent = len(line) - len(line.lstrip())
+        if line.strip() and indent <= parent_indent:
+            parent_indent = None
+            continue
+        match = key_re.match(line)
+        if match and len(match.group(1)) > parent_indent:
+            return match.group(2).strip().strip("\"'")
+    return None
+
+
+def _sim_timestep(run_dir: Path) -> float | None:
+    for name in ("env.yaml", "env_cfg.yaml", "environment.yaml"):
+        path = run_dir / "params" / name
+        for parent in ("sim", "simulation"):
+            value = _yaml_nested_scalar(path, parent, "dt") if path.is_file() else None
+            if value is not None:
+                try:
+                    return float(value)
+                except ValueError:
+                    pass
+    return None
+
+
+def _latest_checkpoint(run_dir: Path) -> str | None:
+    candidates = list(run_dir.glob("model_*.pt"))
+    checkpoint_dir = run_dir / "checkpoint"
+    if checkpoint_dir.is_dir():
+        candidates.extend(checkpoint_dir.rglob("*.pt"))
+    if not candidates:
+        return None
+    def key(path: Path) -> tuple[int, float]:
+        match = CHECKPOINT_RE.search(path.stem)
+        try:
+            modified = path.stat().st_mtime
+        except OSError:
+            modified = 0.0
+        return (int(match.group(1)) if match else -1, modified)
+    return max(candidates, key=key).relative_to(run_dir).as_posix()
+
+
+def _configuration_files(run_dir: Path) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in {".yaml", ".yml", ".json", ".toml"}:
+            continue
+        relative = path.relative_to(run_dir)
+        is_params = bool(relative.parts) and relative.parts[0] == "params"
+        looks_config = any(token in path.stem.lower() for token in ("config", "cfg"))
+        if not is_params and not looks_config:
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        files.append({"path": relative.as_posix(), "size_bytes": size})
+        if len(files) >= 64:
+            break
+    return files
+
+
+def _first(sources: tuple[dict[str, Any], ...], *keys: str) -> Any:
+    for source in sources:
+        for key in keys:
+            value = source.get(key)
+            if value is not None:
+                return value
+    return None
+
+
+def build_run_info(run_dir: Path, root: Path, stage: str) -> dict[str, Any]:
+    status = _json(run_status_path(run_dir, root)) or {}
+    manifest = _json(run_dir / "training_manifest.json") or {}
+    git_data = _first((status, manifest), "git")
+    git_data = git_data if isinstance(git_data, dict) else {}
+    agent = run_dir / "params" / "agent.yaml"
+    env = run_dir / "params" / "env.yaml"
+    seed = _first((status, manifest), "seed")
+    if seed is None and agent.is_file():
+        raw = _yaml_scalar(agent, "seed")
+        if raw is not None:
+            try:
+                seed = int(raw)
+            except ValueError:
+                seed = raw
+    device = _first((status, manifest), "device")
+    if device is None:
+        for path in (agent, env):
+            raw = _yaml_scalar(path, "device") if path.is_file() else None
+            if raw:
+                device = raw
+                break
+    sim_timestep = _first((status, manifest), "simulation_timestep", "sim_timestep", "sim_dt")
+    if sim_timestep is None:
+        sim_timestep = _sim_timestep(run_dir)
+    return {
+        "git_commit": _first((status, manifest, git_data), "git_commit", "commit", "sha"),
+        "git_branch": _first((status, manifest, git_data), "git_branch", "branch"),
+        "task": _first((status, manifest), "task"), "stage": stage, "seed": seed,
+        "command": _first((status, manifest), "command", "command_line"),
+        "simulation_timestep": sim_timestep, "device": device,
+        "checkpoint_path": _first((status, manifest), "checkpoint_path", "model_path") or _latest_checkpoint(run_dir),
+        "model_path": _first((status, manifest), "model_path"),
+        "configuration_files": _configuration_files(run_dir),
+        "started_at": _first((status, manifest), "started_at", "start_time"),
+        "finished_at": _first((status, manifest), "finished_at", "end_time"),
+        "exit_code": _first((status, manifest), "exit_code"),
+    }
+
+
+def training_health(records: list[dict[str, Any]]) -> dict[str, Any]:
+    invalid_updates = 0
+    non_finite_updates = 0
+    names: set[str] = set()
+    for record in records:
+        if record.get("has_non_finite"):
+            non_finite_updates += 1
+            names.update(record.get("non_finite_metrics") or [])
+        invalid = (record.get("canonical_metrics") or {}).get("invalid_update")
+        if _finite(invalid) and float(invalid) > 0:
+            invalid_updates += int(max(1, round(float(invalid))))
+    latest = records[-1] if records else {}
+    return {
+        "invalid_updates": invalid_updates,
+        "non_finite_updates": non_finite_updates,
+        "non_finite_metrics": sorted(names),
+        "latest": latest.get("canonical_metrics") or {},
+    }
+
+
+def summarize_dashboard_run(
+    run_dir: Path, root: Path, *, stale_after_seconds: float = 90.0, detailed: bool = False, now: float | None = None
+) -> dict[str, Any]:
+    now = time.time() if now is None else now
+    base = monitor.summarize_run(run_dir, root, now=now)
+    records = load_dashboard_records(run_dir, limit=500 if detailed else 1)
+    latest = records[-1] if records else None
+    status_file = run_status_path(run_dir, root)
+    status = _json(status_file) or base.get("status") or {}
+    modified_at = float(base.get("modified_at") or 0.0)
+    wall = latest.get("wall_time") if latest else None
+    freshness = max(0.0, now - float(wall)) if _finite(wall) else max(0.0, now - modified_at)
+    state = status.get("state") or base.get("state") or "unknown"
+    process = process_status(status.get("pid"))
+    stale = state in {"starting", "running"} and freshness > stale_after_seconds
+    if state == "running" and process["alive"] is False:
+        stale = True
+    base.update({
+        "state": state, "status": status, "telemetry": latest,
+        "stale": stale, "stale_after_seconds": stale_after_seconds,
+        "freshness_seconds": freshness, "process": process,
+        "status_source": status_file.relative_to(root).as_posix() if status_file.is_file() and _inside(status_file, root) else None,
+    })
+    if detailed:
+        base["training_health"] = training_health(records)
+        base["run_info"] = build_run_info(run_dir, root, str(base.get("stage") or "unknown"))
+        base["system"] = gpu_snapshot(status.get("pid"))
+    return base
+
+
+def list_dashboard_summaries(root: Path, *, stale_after_seconds: float = 90.0) -> list[dict[str, Any]]:
+    return [
+        summarize_dashboard_run(ref.path, root, stale_after_seconds=stale_after_seconds)
+        for ref in discover_dashboard_runs(root)
+    ]

--- a/dashboard/health.py
+++ b/dashboard/health.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,17 @@ def _json(path: Path) -> dict[str, Any] | None:
 
 def _finite(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def _timestamp(value: Any) -> float | None:
+    if _finite(value):
+        return float(value)
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
 
 
 def canonical_metrics(metrics: dict[str, Any]) -> dict[str, float | int | None]:
@@ -409,6 +421,11 @@ def summarize_dashboard_run(
     wall = latest.get("wall_time") if latest else None
     freshness = max(0.0, now - float(wall)) if _finite(wall) else max(0.0, now - modified_at)
     state = status.get("state") or base.get("state") or "unknown"
+    if latest is not None:
+        started = _timestamp(status.get("started_at"))
+        event_time = _timestamp(latest.get("wall_time"))
+        if started is not None and event_time is not None:
+            latest["elapsed_seconds"] = max(0.0, event_time - started)
     process = process_status(status.get("pid"))
     stale = state in {"starting", "running"} and freshness > stale_after_seconds
     if state == "running" and process["alive"] is False:

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -1,4 +1,4 @@
-"""Launch an mjlab/RSL-RL run with durable console logging."""
+"""Launch an mjlab/RSL-RL run with durable dashboard metadata and console logging."""
 from __future__ import annotations
 
 import argparse
@@ -7,10 +7,13 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+from dashboard.config import REPO_ROOT, load_config
 
 
-def write_status(path: Path, **values) -> None:
-    current = {}
+def write_status(path: Path, **values: Any) -> None:
+    current: dict[str, Any] = {}
     if path.exists():
         try:
             current = json.loads(path.read_text(encoding="utf-8"))
@@ -22,14 +25,105 @@ def write_status(path: Path, **values) -> None:
     tmp.replace(path)
 
 
-def main() -> int:
+def _git_value(*args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def git_metadata() -> dict[str, Any]:
+    commit = _git_value("rev-parse", "HEAD")
+    branch = _git_value("branch", "--show-current")
+    dirty = None
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+        dirty = bool(result.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return {"commit": commit, "branch": branch, "dirty": dirty}
+
+
+def _training_arg(training_args: list[str], *names: str) -> str | None:
+    """Return the last value supplied for one of the CLI option names."""
+    value: str | None = None
+    for index, token in enumerate(training_args):
+        for name in names:
+            if token == name and index + 1 < len(training_args):
+                value = training_args[index + 1]
+            elif token.startswith(name + "="):
+                value = token.split("=", 1)[1]
+    return value
+
+
+def _number(value: str | None) -> int | float | str | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def _latest_checkpoint(run_dir: Path) -> str | None:
+    candidates = list(run_dir.rglob("model_*.pt"))
+    if not candidates:
+        return None
+
+    def key(path: Path) -> tuple[int, float]:
+        number = -1
+        stem = path.stem
+        suffix = stem.rsplit("_", 1)[-1]
+        if suffix.isdigit():
+            number = int(suffix)
+        try:
+            modified = path.stat().st_mtime
+        except OSError:
+            modified = 0.0
+        return number, modified
+
+    latest = max(candidates, key=key)
+    return latest.relative_to(run_dir).as_posix()
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run mjlab training while capturing console output for the dashboard."
     )
-    parser.add_argument("--artifact-root", type=Path, default=Path("logs/rsl_rl"))
+    default_artifact_root = load_config().artifact_root
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=default_artifact_root,
+        help=f"dashboard/training artifact root (default: {default_artifact_root})",
+    )
     parser.add_argument("--name", help="run directory name; defaults to timestamp_stage")
     parser.add_argument("--task", default="Ascento-Balance-Flat")
     parser.add_argument("training_args", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
     training_args = list(args.training_args)
@@ -39,60 +133,135 @@ def main() -> int:
         parser.error("do not pass --output; dashboard.launch assigns an isolated run directory")
 
     stage = args.task.removeprefix("Ascento-").removesuffix("-Flat").lower()
-
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     run_name = args.name or f"{stamp}_{stage}"
-    run_dir = (args.artifact_root / run_name).resolve()
-    if run_dir.exists() and any(run_dir.iterdir()):
-        parser.error(f"run directory already exists and is not empty: {run_dir}")
-    run_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = (args.artifact_root.expanduser().resolve() / run_name).resolve()
+
+    try:
+        if run_dir.exists() and any(run_dir.iterdir()):
+            parser.error(f"run directory already exists and is not empty: {run_dir}")
+        run_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        parser.error(f"cannot create run directory {run_dir}: {error}")
 
     status_path = run_dir / "run_status.json"
     log_path = run_dir / "training.log"
     command = [
         sys.executable,
         "-u",
-        "-m", "mjlab.scripts.train",
+        "-m",
+        "mjlab.scripts.train",
         args.task,
         *training_args,
-        "--log-root", str(run_dir),
+        "--log-root",
+        str(run_dir),
     ]
+
+    seed = _number(_training_arg(training_args, "--seed", "--agent.seed"))
+    device = _training_arg(
+        training_args,
+        "--device",
+        "--env.device",
+        "--agent.device",
+    )
+    sim_timestep = _number(
+        _training_arg(
+            training_args,
+            "--env.sim.dt",
+            "--sim.dt",
+            "--simulation.dt",
+        )
+    )
     started = datetime.now(timezone.utc).isoformat()
+    git = git_metadata()
+
     write_status(
         status_path,
+        schema_version=2,
         state="starting",
+        task=args.task,
         stage=stage,
+        seed=seed,
+        device=device,
+        simulation_timestep=sim_timestep,
         started_at=started,
         command=command,
+        command_line=" ".join(command),
+        python_executable=sys.executable,
+        artifact_root=str(args.artifact_root.expanduser().resolve()),
+        run_directory=str(run_dir),
+        git=git,
+        git_commit=git.get("commit"),
+        git_branch=git.get("branch"),
         exit_code=None,
     )
 
-    with log_path.open("a", encoding="utf-8", buffering=1) as log:
-        log.write("DASHBOARD_LAUNCH " + " ".join(command) + "\n")
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
+    exit_code = 127
+    try:
+        with log_path.open("a", encoding="utf-8", buffering=1) as log:
+            log.write("DASHBOARD_LAUNCH " + " ".join(command) + "\n")
+            try:
+                process = subprocess.Popen(
+                    command,
+                    cwd=REPO_ROOT,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+            except OSError as error:
+                message = f"Dashboard launcher could not start training: {error}"
+                log.write(message + "\n")
+                print(message, file=sys.stderr)
+                write_status(
+                    status_path,
+                    state="error",
+                    launch_error=str(error),
+                    exit_code=127,
+                    finished_at=datetime.now(timezone.utc).isoformat(),
+                )
+                return 127
+
+            write_status(status_path, state="running", pid=process.pid)
+            try:
+                assert process.stdout is not None
+                for line in process.stdout:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+                    log.write(line)
+                exit_code = process.wait()
+            except KeyboardInterrupt:
+                process.terminate()
+                exit_code = process.wait()
+                write_status(
+                    status_path,
+                    state="cancelled",
+                    exit_code=exit_code,
+                    finished_at=datetime.now(timezone.utc).isoformat(),
+                    checkpoint_path=_latest_checkpoint(run_dir),
+                )
+                raise
+    except OSError as error:
+        message = f"Dashboard launcher cannot write {log_path}: {error}"
+        print(message, file=sys.stderr)
+        write_status(
+            status_path,
+            state="error",
+            launch_error=str(error),
+            exit_code=127,
+            finished_at=datetime.now(timezone.utc).isoformat(),
         )
-        write_status(status_path, state="running", pid=process.pid)
-        try:
-            assert process.stdout is not None
-            for line in process.stdout:
-                sys.stdout.write(line)
-                sys.stdout.flush()
-                log.write(line)
-            exit_code = process.wait()
-        except KeyboardInterrupt:
-            process.terminate()
-            exit_code = process.wait()
-            write_status(status_path, state="cancelled", exit_code=exit_code)
-            raise
+        return 127
 
     finished = datetime.now(timezone.utc).isoformat()
     state = "finished" if exit_code == 0 else "error"
-    write_status(status_path, state=state, exit_code=exit_code, finished_at=finished)
+    write_status(
+        status_path,
+        state=state,
+        exit_code=exit_code,
+        finished_at=finished,
+        checkpoint_path=_latest_checkpoint(run_dir),
+    )
     return exit_code
 
 

--- a/scripts/run_dashboard.sh
+++ b/scripts/run_dashboard.sh
@@ -4,13 +4,19 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST="${ASCENTO_DASHBOARD_DIST:-$ROOT/dashboard/frontend/dist}"
 
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Dashboard startup failed: uv is not installed or not on PATH." >&2
+  echo "Install uv, then run: uv sync --frozen --extra dashboard" >&2
+  exit 1
+fi
+
 if [[ ! -f "$DIST/index.html" ]]; then
-  echo "Dashboard frontend is not built." >&2
+  echo "Dashboard frontend is not built: $DIST/index.html is missing." >&2
   echo "Run: cd dashboard/frontend && npm install && npm run build" >&2
   exit 1
 fi
 
 cd "$ROOT"
-exec python -m uvicorn dashboard.app:app \
+exec uv run --frozen --extra dashboard python -m uvicorn dashboard.app:app \
   --host "${ASCENTO_DASHBOARD_HOST:-127.0.0.1}" \
   --port "${ASCENTO_DASHBOARD_PORT:-8000}"

--- a/tests_dashboard/test_backend.py
+++ b/tests_dashboard/test_backend.py
@@ -1,13 +1,56 @@
 import importlib
+import json
 
 
-def test_dashboard_backend_imports_and_registers_health_route(monkeypatch, tmp_path):
-  monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(tmp_path))
-  module = importlib.import_module("dashboard.app")
+def _load_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(tmp_path))
+    import dashboard.app as dashboard_app
 
-  assert module.app.title == "Ascento Training Monitor"
-  assert any(route.path == "/api/health" for route in module.app.routes)
-  assert module.health() == {
-    "ok": True,
-    "artifact_root": str(tmp_path.resolve()),
-  }
+    return importlib.reload(dashboard_app)
+
+
+def test_dashboard_backend_registers_health_and_config_routes(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    assert module.app.title == "Ascento Training Monitor"
+    paths = {route.path for route in module.app.routes}
+    assert "/api/health" in paths
+    assert "/api/config" in paths
+    assert "/api/runs/{run_id}/summary.json" in paths
+
+    health = module.health()
+    assert health["ok"] is True
+    assert health["artifact_root"] == str(tmp_path.resolve())
+    assert health["config"]["artifact_root"] == str(tmp_path.resolve())
+    assert module.configuration()["stale_after_seconds"] > 0
+
+
+def test_run_summary_download_is_json_safe(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run_status.json").write_text(
+        json.dumps(
+            {
+                "state": "finished",
+                "task": "Ascento-Balance-Flat",
+                "stage": "balance",
+                "exit_code": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "telemetry.jsonl").write_text(
+        '{"completed_steps": 4, "total_steps": 10, "wall_time": 1, '
+        '"metrics": {"Train/mean_reward": NaN}}\n',
+        encoding="utf-8",
+    )
+
+    run_id = module.runs()["runs"][0]["id"]
+    response = module.run_summary(run_id)
+    payload = json.loads(response.body)
+
+    assert response.headers["content-disposition"] == 'attachment; filename="run-summary.json"'
+    assert payload["run_info"]["task"] == "Ascento-Balance-Flat"
+    assert payload["training_health"]["non_finite_updates"] == 1
+    assert payload["telemetry"]["metrics"]["Train/mean_reward"] is None

--- a/tests_dashboard/test_config_launch.py
+++ b/tests_dashboard/test_config_launch.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+from dashboard.config import load_config, validate_startup
+from dashboard.launch import _training_arg, build_parser
+
+
+def test_launcher_uses_same_default_artifact_root_as_dashboard(monkeypatch, tmp_path):
+    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(tmp_path))
+    config = load_config()
+    args = build_parser().parse_args([])
+
+    assert args.artifact_root == config.artifact_root == tmp_path.resolve()
+
+
+def test_launcher_argument_metadata_parser_supports_both_cli_forms():
+    args = [
+        "--seed=7",
+        "--device",
+        "cuda:0",
+        "--env.sim.dt",
+        "0.002",
+        "--agent.seed",
+        "11",
+    ]
+
+    assert _training_arg(args, "--seed", "--agent.seed") == "11"
+    assert _training_arg(args, "--device") == "cuda:0"
+    assert _training_arg(args, "--env.sim.dt") == "0.002"
+
+
+def test_startup_validation_reports_bad_artifact_root(tmp_path):
+    bad_root = tmp_path / "artifact-file"
+    bad_root.write_text("not a directory", encoding="utf-8")
+    monkeypatch_config = load_config()
+    config = type(monkeypatch_config)(
+        repo_root=monkeypatch_config.repo_root,
+        artifact_root=bad_root,
+        frontend_dist=monkeypatch_config.frontend_dist,
+        stale_after_seconds=monkeypatch_config.stale_after_seconds,
+    )
+
+    with pytest.raises(RuntimeError, match="artifact root is not a directory"):
+        validate_startup(config)

--- a/tests_dashboard/test_monitor.py
+++ b/tests_dashboard/test_monitor.py
@@ -1,0 +1,156 @@
+import json
+import os
+
+from dashboard.health import (
+    decorate_records,
+    discover_dashboard_runs,
+    load_dashboard_records,
+    summarize_dashboard_run,
+)
+
+
+def test_canonical_metrics_and_non_finite_detection(tmp_path):
+    record = decorate_records(
+        [{
+            "completed_steps": 3,
+            "metrics": {
+                "Train/mean_reward": 2.5,
+                "Train/mean_episode_length": 42.0,
+                "Loss/surrogate": 0.12,
+                "Loss/entropy": -0.02,
+                "Loss/kl": 0.006,
+                "Policy/clip_fraction": 0.17,
+                "bad_metric": float("inf"),
+            },
+        }],
+        tmp_path,
+    )[0]
+
+    assert record["canonical_metrics"]["reward"] == 2.5
+    assert record["canonical_metrics"]["episode_length"] == 42.0
+    assert record["canonical_metrics"]["ppo_loss"] == 0.12
+    assert record["canonical_metrics"]["kl"] == 0.006
+    assert record["canonical_metrics"]["clip_fraction"] == 0.17
+    assert record["metrics"]["bad_metric"] is None
+    assert record["has_non_finite"] is True
+    assert record["canonical_metrics"]["invalid_update"] == 1
+
+
+def test_nested_launcher_run_is_discovered_once_and_inherits_metadata(tmp_path):
+    launch_dir = tmp_path / "20260903_balance"
+    actual_run = launch_dir / "ascento_balance" / "2026-09-03_13-00-00"
+    actual_run.mkdir(parents=True)
+    (launch_dir / "training.log").write_text("training\n", encoding="utf-8")
+    (launch_dir / "run_status.json").write_text(
+        json.dumps(
+            {
+                "state": "running",
+                "task": "Ascento-Balance-Flat",
+                "stage": "balance",
+                "seed": 12,
+                "device": "cuda:0",
+                "started_at": "2026-09-03T11:00:00+00:00",
+                "command": ["python", "-m", "mjlab.scripts.train"],
+                "pid": os.getpid(),
+                "git_commit": "abc123",
+                "git_branch": "feature/test",
+            }
+        ),
+        encoding="utf-8",
+    )
+    params = actual_run / "params"
+    params.mkdir()
+    (params / "agent.yaml").write_text("max_iterations: 100\n", encoding="utf-8")
+    (params / "env.yaml").write_text("sim:\n  dt: 0.002\n", encoding="utf-8")
+    (actual_run / "model_20.pt").write_bytes(b"")
+    (actual_run / "telemetry.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "completed_steps": 10,
+                        "total_steps": 100,
+                        "wall_time": 800.0,
+                        "metrics": {
+                            "Train/mean_reward": 1.0,
+                            "Train/mean_episode_length": 30.0,
+                            "Perf/total_fps": 5000.0,
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "completed_steps": 20,
+                        "total_steps": 100,
+                        "wall_time": 810.0,
+                        "metrics": {
+                            "Train/mean_reward": 2.0,
+                            "Train/mean_episode_length": 40.0,
+                            "Perf/total_fps": 5200.0,
+                            "training/invalid_update": 1,
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    refs = discover_dashboard_runs(tmp_path)
+    assert len(refs) == 1
+    assert refs[0].path == actual_run.resolve()
+
+    summary = summarize_dashboard_run(
+        actual_run,
+        tmp_path,
+        now=1000.0,
+        stale_after_seconds=90.0,
+        detailed=True,
+    )
+
+    assert summary["stale"] is True
+    assert summary["freshness_seconds"] == 190.0
+    assert summary["process"]["alive"] is True
+    assert summary["run_info"]["git_commit"] == "abc123"
+    assert summary["run_info"]["task"] == "Ascento-Balance-Flat"
+    assert summary["run_info"]["seed"] == 12
+    assert summary["run_info"]["simulation_timestep"] == 0.002
+    assert summary["run_info"]["checkpoint_path"] == "model_20.pt"
+    assert summary["training_health"]["invalid_updates"] == 1
+    assert summary["telemetry"]["iteration"] == 20
+    assert summary["telemetry"]["eta_seconds"] == 80.0
+
+
+def test_jsonl_eta_uses_iteration_rate_not_environment_fps(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "telemetry.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "completed_steps": 0,
+                        "total_steps": 100,
+                        "wall_time": 100.0,
+                        "metrics": {"Perf/total_fps": 100000.0},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "completed_steps": 10,
+                        "total_steps": 100,
+                        "wall_time": 110.0,
+                        "metrics": {"Perf/total_fps": 100000.0},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    records = load_dashboard_records(run_dir)
+    assert records[-1]["steps_per_second"] == 100000.0
+    assert records[-1]["iterations_per_second"] == 1.0
+    assert records[-1]["eta_seconds"] == 90.0


### PR DESCRIPTION
## Summary

Implements dashboard Pass 4A through 4C as one reliability/reproducibility pass.

### Pass 4A — make the current dashboard reliable
- fixes the artifact-root mismatch by sharing one default/config path between the server and `dashboard.launch` (`logs/rsl_rl`)
- moves documented/scripted startup onto the uv-managed project environment
- adds explicit startup validation and useful configuration diagnostics
- adds an API health indicator and `/api/config`
- expands dashboard backend tests and CI coverage, including shell syntax checking
- collapses launcher-wrapper directories and nested RSL-RL output into one logical dashboard run

Closes #59
Closes #63
Builds on the backend/API coverage introduced for #61.

### Pass 4B — training health monitoring
- current iteration and telemetry freshness
- environment throughput and iteration-rate ETA
- reward and episode-length trends
- PPO/surrogate loss, entropy, KL, and clip fraction when emitted by the trainer
- invalid-update and NaN/Inf detection
- GPU utilization, memory, temperature, process GPU memory, PID and process liveness via `nvidia-smi`
- configurable stale-run detection (`ASCENTO_STALE_AFTER_SECONDS`, default 90 s)

### Pass 4C — run metadata and reproducibility
- records Git commit/branch, task/stage, seed, exact command, device, supplied simulation timestep, start/end time, exit code and latest checkpoint
- infers saved seed/device/timestep/configuration files from run params for older/non-launcher runs when available
- displays run metadata in the dashboard
- adds **Copy run information** and downloadable `run-summary.json`
- displays the active artifact root, frontend build path, Python interpreter, stale threshold and detected-run count

## Verification
- backend/config/health tests added for canonical metrics, non-finite telemetry, stale runs, nested run discovery, metadata inheritance, shared artifact root, JSON-safe run summaries, and ETA calculation
- local focused dashboard test suite passed before push
- Python modules compile cleanly
- frontend JSX syntax was parsed successfully locally
- GitHub Dashboard CI will run backend, dashboard-backend, shell syntax, and frontend build checks on this PR
