### PR TITLE
Fix dashboard startup with read-only artifact mounts

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -22,7 +22,9 @@ from dashboard.monitor import tail_lines, training_log_path
 from dashboard.versioning import annotate_run_summary, current_repository_version
 
 CONFIG = load_config()
-STARTUP_WARNINGS = validate_startup(CONFIG)
+# The server only monitors artifacts. Docker intentionally mounts logs/checkpoints/
+# captures read-only, so startup validation must never try to create directories.
+STARTUP_WARNINGS = validate_startup(CONFIG, create_artifact_root=False)
 ARTIFACT_ROOT = CONFIG.artifact_root
 FRONTEND_DIST = CONFIG.frontend_dist
 
@@ -43,11 +45,12 @@ def _run(run_id: str):
 
 def _artifact_health() -> list[str]:
     problems: list[str] = []
-    if not ARTIFACT_ROOT.exists():
-        problems.append(f"artifact root does not exist: {ARTIFACT_ROOT}")
-    elif not ARTIFACT_ROOT.is_dir():
+    # A missing root is normal on a fresh install before the first training run.
+    # discover_runs() treats it as an empty run set, so it is a warning rather
+    # than a health failure.
+    if ARTIFACT_ROOT.exists() and not ARTIFACT_ROOT.is_dir():
         problems.append(f"artifact root is not a directory: {ARTIFACT_ROOT}")
-    else:
+    elif ARTIFACT_ROOT.exists():
         if not os.access(ARTIFACT_ROOT, os.R_OK):
             problems.append(f"artifact root is not readable: {ARTIFACT_ROOT}")
         if not os.access(ARTIFACT_ROOT, os.X_OK):

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -67,7 +67,12 @@ def load_config() -> DashboardConfig:
 
 
 def validate_startup(config: DashboardConfig, *, create_artifact_root: bool = True) -> list[str]:
-    """Validate paths early and return non-fatal startup warnings."""
+    """Validate paths early and return non-fatal startup warnings.
+
+    The dashboard server is a read-only monitor and should pass
+    ``create_artifact_root=False``. Writers such as the launcher may retain the
+    default and create the configured artifact root before starting a run.
+    """
     warnings: list[str] = []
 
     if config.artifact_root.exists() and not config.artifact_root.is_dir():
@@ -85,6 +90,11 @@ def validate_startup(config: DashboardConfig, *, create_artifact_root: bool = Tr
                 f"{config.artifact_root}: {error}. "
                 "Set ASCENTO_ARTIFACT_ROOT to a writable directory."
             ) from error
+    elif not config.artifact_root.exists():
+        warnings.append(
+            "Dashboard artifact root does not exist yet: "
+            f"{config.artifact_root}. No runs will be shown until training creates it."
+        )
 
     if config.artifact_root.exists():
         if not os.access(config.artifact_root, os.R_OK):

--- a/tests_dashboard/test_backend.py
+++ b/tests_dashboard/test_backend.py
@@ -2,8 +2,8 @@ import importlib
 import json
 
 
-def _load_app(monkeypatch, tmp_path):
-    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(tmp_path))
+def _load_app(monkeypatch, artifact_root):
+    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(artifact_root))
     import dashboard.app as dashboard_app
 
     return importlib.reload(dashboard_app)
@@ -23,6 +23,21 @@ def test_dashboard_backend_registers_health_and_config_routes(monkeypatch, tmp_p
     assert health["artifact_root"] == str(tmp_path.resolve())
     assert health["config"]["artifact_root"] == str(tmp_path.resolve())
     assert module.configuration()["stale_after_seconds"] > 0
+
+
+def test_dashboard_starts_before_read_only_artifact_root_exists(monkeypatch, tmp_path):
+    artifact_root = tmp_path / "logs" / "rsl_rl"
+    assert artifact_root.exists() is False
+
+    module = _load_app(monkeypatch, artifact_root)
+    health = module.health()
+
+    assert artifact_root.exists() is False
+    assert health["ok"] is True
+    assert health["run_count"] == 0
+    assert health["problems"] == []
+    assert any("does not exist yet" in warning for warning in health["warnings"])
+    assert module.runs() == {"runs": []}
 
 
 def test_run_summary_download_is_json_safe(monkeypatch, tmp_path):

--- a/tests_dashboard/test_config_launch.py
+++ b/tests_dashboard/test_config_launch.py
@@ -54,3 +54,19 @@ def test_startup_validation_reports_bad_artifact_root(tmp_path):
 
     with pytest.raises(RuntimeError, match="artifact root is not a directory"):
         validate_startup(config)
+
+
+def test_read_only_monitor_validation_does_not_create_missing_artifact_root(tmp_path):
+    missing_root = tmp_path / "logs" / "rsl_rl"
+    base = load_config()
+    config = type(base)(
+        repo_root=base.repo_root,
+        artifact_root=missing_root,
+        frontend_dist=base.frontend_dist,
+        stale_after_seconds=base.stale_after_seconds,
+    )
+
+    warnings = validate_startup(config, create_artifact_root=False)
+
+    assert missing_root.exists() is False
+    assert any("does not exist yet" in warning for warning in warnings)


### PR DESCRIPTION
## Summary

Fixes the dashboard crash-loop seen after the maintenance/Docker workflow was merged.

The dashboard service intentionally mounts `logs`, `checkpoints`, and `captures` read-only, but `dashboard.app` still called `validate_startup()` in write/create mode. On a fresh install where `/workspace/logs/rsl_rl` does not exist yet, startup attempted `mkdir` inside the read-only bind mount and failed with `Errno 30`.

### Fix
- run dashboard server validation with `create_artifact_root=False`
- keep Docker artifact mounts read-only
- treat a missing artifact root as the normal zero-run state on a fresh installation rather than an API health failure
- retain hard failures for paths that exist but are not directories, unreadable, or unsearchable
- add a non-fatal startup warning when the read-only monitor root does not exist yet

### Regression coverage
- verifies read-only monitor validation never creates the artifact directory
- verifies the FastAPI dashboard imports/starts with a missing artifact root, reports healthy status and zero runs, and leaves the path untouched

This directly addresses the observed crash: `RuntimeError: Dashboard could not create the artifact root /workspace/logs/rsl_rl: [Errno 30] Read-only file system`.