### PR TITLE
Fix balance action authority and training telemetry correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ and tests.
 
 The initial direct-effort actuator uses six normalized actions in `[-1, 1]`,
 40 Nm peak simulation authority, a linear torque-speed envelope, controller
-speed protection, and finite torque response. The 15 Nm leg and 5 Nm wheel
-continuous ratings are documentation only until a thermal/duration model is
-justified. No communication delay, sensor noise, or thermal model is enabled.
+speed protection, and finite torque response. Training clips the policy action
+to `[-1, 1]` before the environment maps it to a physical `[-40, 40] Nm`
+effort target. The 15 Nm leg and 5 Nm wheel continuous ratings are documentation
+only until a thermal/duration model is justified. No communication delay, sensor
+noise, or thermal model is enabled.
 
 ## Maintenance / first-time install
 
@@ -98,13 +100,15 @@ RSL-RL versions, then runs 100 finite Warp steps. Start balance training with
 the standard mjlab entry point after Gate D review:
 
 ```bash
-uv run --extra cu128 train Ascento-Balance-Flat --num-envs 512
+uv run --extra cu128 train Ascento-Balance-Flat --env.scene.num-envs 512
 uv run --extra cu128 play Ascento-Balance-Flat --agent zero
 ```
 
 Gate D is mjlab-native: the validated plant must learn robust, visually
-plausible balance with sensible control. Old-stack policy behavior is a
-diagnostic reference only, never the acceptance target.
+plausible balance with sensible control. The balance objective mildly penalizes
+horizontal root speed so recovery motion remains available without rewarding
+persistent drift. Old-stack policy behavior is a diagnostic reference only,
+never the acceptance target.
 
 ## Tasks and sequencing
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,12 +5,13 @@ training artifacts and launcher metadata; it does not own the PPO algorithm itse
 
 ## What it shows
 
-- current iteration, wall-clock freshness, throughput, elapsed time and ETA;
+- current iteration, wall-clock freshness, environment-step throughput, elapsed time and ETA;
+- explicit iteration counts plus collected environment-transition totals when run config is available;
 - reward and episode-length trends;
 - PPO/surrogate loss, value loss, entropy, KL, clip fraction and invalid-update telemetry when reported by the trainer;
 - NaN/Inf detection across numeric telemetry;
 - stale-run detection when a run is still marked running but telemetry stops;
-- GPU utilization, memory, temperature, process PID/aliveness and per-process GPU memory when `nvidia-smi` is available;
+- GPU utilization, memory and temperature, plus process-specific telemetry only when the dashboard shares the trainer's PID namespace;
 - recent traceback/error excerpts and live console output;
 - Git commit/branch, task/stage, seed, command line, timestep/device, checkpoint path, configuration files, start/end time and exit code;
 - a copyable run-information block and downloadable `run-summary.json`;
@@ -85,6 +86,13 @@ The API exposes:
 - `/api/runs/<id>/telemetry` — normalized training telemetry;
 - `/api/runs/<id>/logs` and `/logs/stream` — captured console output.
 
+Native RSL-RL TensorBoard event steps are PPO iterations, not environment
+transitions. The normalized telemetry therefore uses `iteration`,
+`completed_iterations`, and `total_iterations` for progress. When
+`num_steps_per_env` and `scene.num_envs` are available, it also reports
+`environment_steps` and `total_environment_steps`. `Perf/total_fps` is exposed
+as environment-step throughput rather than iteration throughput.
+
 `ASCENTO_STALE_AFTER_SECONDS` controls the stale-run threshold and defaults to
 90 seconds.
 
@@ -99,9 +107,10 @@ uv run --frozen --extra cu128 python -m dashboard.launch \
 ```
 
 `dashboard.launch` captures durable run metadata before starting the trainer,
-including the current Git commit/branch, the exact command, task/stage, seed,
-device and simulation timestep when supplied on the command line. It updates the
-same status record with PID, finish time, exit code and latest checkpoint.
+including the current Git commit/branch and exact command. It also updates the
+status record from the trainer's runtime output with the actual seed/device and
+records the launcher's PID namespace so a dashboard in another container does
+not misidentify an unrelated same-numbered PID as the trainer.
 
 To override the shared root for both the launcher and server:
 

--- a/dashboard/health.py
+++ b/dashboard/health.py
@@ -18,14 +18,19 @@ ALIASES: dict[str, tuple[str, ...]] = {
     "reward": ("Train/mean_reward", "train/mean_reward", "eval/episode_reward", "Episode/reward", "episode_reward"),
     "episode_length": ("Train/mean_episode_length", "train/mean_episode_length", "eval/avg_episode_length", "Episode/length", "episode_length"),
     "ppo_loss": ("Loss/surrogate", "loss/surrogate", "training/policy_loss", "training/total_loss", "ppo_loss"),
-    "value_loss": ("Loss/value_function", "loss/value_function", "training/v_loss", "value_loss"),
+    "value_loss": ("Loss/value", "Loss/value_function", "loss/value_function", "training/v_loss", "value_loss"),
     "entropy": ("Loss/entropy", "loss/entropy", "Policy/entropy", "training/entropy", "training/entropy_loss", "entropy"),
     "kl": ("Loss/kl", "loss/kl", "Policy/kl", "training/kl", "training/approx_kl", "approx_kl", "kl"),
-    "clip_fraction": ("Policy/clip_fraction", "Loss/clip_fraction", "training/clip_fraction", "clip_fraction"),
+    "clip_fraction": ("Loss/clip_fraction", "Policy/clip_fraction", "training/clip_fraction", "clip_fraction"),
+    "learning_rate": ("Loss/learning_rate", "training/learning_rate", "learning_rate"),
     "invalid_update": ("training/invalid_update", "Train/invalid_update", "invalid_update"),
     "throughput": ("Perf/total_fps", "perf/total_fps", "training/fps", "steps_per_second"),
 }
 CHECKPOINT_RE = re.compile(r"(?:model|checkpoint)[_-]?(\d+)", re.IGNORECASE)
+TRAINING_RUNTIME_RE = re.compile(
+    r"Training with:\s*device=([^,\s]+),\s*seed=([^,\s]+),\s*rank=(\d+)"
+)
+GPU_WORLD_RE = re.compile(r"Launching training with\s+(\d+)\s+GPUs?", re.IGNORECASE)
 
 
 def _inside(path: Path, root: Path) -> bool:
@@ -59,6 +64,13 @@ def _timestamp(value: Any) -> float | None:
         return None
 
 
+def _pid_namespace() -> str | None:
+    try:
+        return os.readlink("/proc/self/ns/pid")
+    except OSError:
+        return None
+
+
 def canonical_metrics(metrics: dict[str, Any]) -> dict[str, float | int | None]:
     result: dict[str, float | int | None] = {}
     for canonical, aliases in ALIASES.items():
@@ -84,10 +96,54 @@ def _training_limit(run_dir: Path) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def _yaml_path_scalar(path: Path, keys: tuple[str, ...]) -> str | None:
+    """Read one scalar from a simple nested YAML mapping without a YAML dependency."""
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+
+    stack: list[tuple[int, str]] = []
+    item_re = re.compile(r"^(\s*)([^:#][^:]*):(?:\s*(.*?))?\s*$")
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+            continue
+        match = item_re.match(line)
+        if not match:
+            continue
+        indent = len(match.group(1))
+        key = match.group(2).strip()
+        value = (match.group(3) or "").strip()
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        stack.append((indent, key))
+        if tuple(part for _, part in stack) == keys and value:
+            return value.split("#", 1)[0].strip().strip("\"'")
+    return None
+
+
+def _training_shape(run_dir: Path) -> tuple[int | None, int | None]:
+    agent = run_dir / "params" / "agent.yaml"
+    env = run_dir / "params" / "env.yaml"
+    steps = _yaml_path_scalar(agent, ("num_steps_per_env",)) if agent.is_file() else None
+    envs = _yaml_path_scalar(env, ("scene", "num_envs")) if env.is_file() else None
+    try:
+        steps_value = int(steps) if steps is not None else None
+    except ValueError:
+        steps_value = None
+    try:
+        envs_value = int(envs) if envs is not None else None
+    except ValueError:
+        envs_value = None
+    return steps_value, envs_value
+
+
 def decorate_records(records: list[dict[str, Any]], run_dir: Path) -> list[dict[str, Any]]:
-    """Return JSON-safe telemetry with canonical PPO metrics and iteration-rate ETA."""
+    """Return JSON-safe telemetry with explicit iteration and environment-step units."""
     decorated: list[dict[str, Any]] = []
     total = _training_limit(run_dir)
+    steps_per_env, num_envs = _training_shape(run_dir)
     for source in records:
         record = dict(source)
         raw_metrics = source.get("metrics") if isinstance(source.get("metrics"), dict) else {}
@@ -106,19 +162,35 @@ def decorate_records(records: list[dict[str, Any]], run_dir: Path) -> list[dict[
         record["canonical_metrics"] = canonical
         record["non_finite_metrics"] = non_finite
         record["has_non_finite"] = bool(non_finite)
-        iteration = record.get("iteration", record.get("completed_steps"))
+
+        iteration = record.get(
+            "iteration", record.get("completed_iterations", record.get("completed_steps"))
+        )
         if _finite(iteration):
-            record["iteration"] = int(iteration)
+            iteration = int(iteration)
+            record["iteration"] = iteration
+            record["completed_iterations"] = iteration
+        record.pop("completed_steps", None)
+
         configured_total = record.get("total_iterations", record.get("total_steps", total))
         if _finite(configured_total):
             configured_total = int(configured_total)
             record["total_iterations"] = configured_total
-            record["total_steps"] = configured_total
             if _finite(iteration):
-                record["percent_complete"] = min(100.0, 100.0 * float(iteration) / max(configured_total, 1))
+                record["percent_complete"] = min(
+                    100.0, 100.0 * float(iteration) / max(configured_total, 1)
+                )
+        record.pop("total_steps", None)
+
+        if _finite(iteration) and steps_per_env and num_envs:
+            record["environment_steps"] = int(iteration) * steps_per_env * num_envs
+            if _finite(configured_total):
+                record["total_environment_steps"] = configured_total * steps_per_env * num_envs
+
         throughput = canonical.get("throughput")
         if _finite(throughput) and float(throughput) > 0:
-            record["steps_per_second"] = float(throughput)
+            record["environment_steps_per_second"] = float(throughput)
+        record.pop("steps_per_second", None)
         decorated.append(record)
 
     if not decorated:
@@ -145,7 +217,9 @@ def decorate_records(records: list[dict[str, Any]], run_dir: Path) -> list[dict[
         if delta_i > 0 and delta_t > 0:
             rate = delta_i / delta_t
             record["iterations_per_second"] = rate
-            record["eta_seconds"] = max(0.0, (float(total_iterations) - float(iteration)) / rate)
+            record["eta_seconds"] = max(
+                0.0, (float(total_iterations) - float(iteration)) / rate
+            )
     return decorated
 
 
@@ -183,7 +257,10 @@ def discover_dashboard_runs(root: Path) -> list[monitor.RunRef]:
     for ref in refs:
         path = ref.path.resolve()
         launcher_only = (path / "run_status.json").is_file() and not _has_training_signal(path)
-        has_nested_signal = any(other != path and _inside(other, path) and _has_training_signal(other) for other in paths)
+        has_nested_signal = any(
+            other != path and _inside(other, path) and _has_training_signal(other)
+            for other in paths
+        )
         if launcher_only and has_nested_signal:
             continue
         filtered.append(ref)
@@ -197,9 +274,23 @@ def resolve_dashboard_run(root: Path, run_id: str) -> monitor.RunRef:
     raise KeyError(run_id)
 
 
-def process_status(pid: Any) -> dict[str, Any]:
+def process_status(pid: Any, source_pid_namespace: str | None = None) -> dict[str, Any]:
     if not isinstance(pid, int) or pid <= 0:
-        return {"pid": None, "alive": None}
+        return {"pid": None, "alive": None, "same_namespace": None}
+
+    current_namespace = _pid_namespace()
+    if (
+        source_pid_namespace is not None
+        and current_namespace is not None
+        and source_pid_namespace != current_namespace
+    ):
+        return {
+            "pid": pid,
+            "alive": None,
+            "same_namespace": False,
+            "reason": "different_pid_namespace",
+        }
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -210,7 +301,11 @@ def process_status(pid: Any) -> dict[str, Any]:
         alive = None
     else:
         alive = True
-    return {"pid": pid, "alive": alive}
+    return {
+        "pid": pid,
+        "alive": alive,
+        "same_namespace": True if source_pid_namespace and current_namespace else None,
+    }
 
 
 def gpu_snapshot(pid: int | None = None) -> dict[str, Any]:
@@ -219,8 +314,15 @@ def gpu_snapshot(pid: int | None = None) -> dict[str, Any]:
         return {"available": False, "gpus": [], "process_gpu_memory_mb": None}
     try:
         result = subprocess.run(
-            [executable, "--query-gpu=index,name,uuid,utilization.gpu,memory.used,memory.total,temperature.gpu", "--format=csv,noheader,nounits"],
-            check=True, capture_output=True, text=True, timeout=2.0,
+            [
+                executable,
+                "--query-gpu=index,name,uuid,utilization.gpu,memory.used,memory.total,temperature.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
         )
     except (OSError, subprocess.SubprocessError) as error:
         return {"available": False, "gpus": [], "process_gpu_memory_mb": None, "error": str(error)}
@@ -230,19 +332,32 @@ def gpu_snapshot(pid: int | None = None) -> dict[str, Any]:
         if len(parts) != 7:
             continue
         try:
-            gpus.append({
-                "index": int(parts[0]), "name": parts[1], "uuid": parts[2],
-                "utilization_percent": float(parts[3]), "memory_used_mb": float(parts[4]),
-                "memory_total_mb": float(parts[5]), "temperature_c": float(parts[6]),
-            })
+            gpus.append(
+                {
+                    "index": int(parts[0]),
+                    "name": parts[1],
+                    "uuid": parts[2],
+                    "utilization_percent": float(parts[3]),
+                    "memory_used_mb": float(parts[4]),
+                    "memory_total_mb": float(parts[5]),
+                    "temperature_c": float(parts[6]),
+                }
+            )
         except ValueError:
             continue
     process_memory: float | None = None
     if isinstance(pid, int) and pid > 0:
         try:
             result = subprocess.run(
-                [executable, "--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"],
-                check=True, capture_output=True, text=True, timeout=2.0,
+                [
+                    executable,
+                    "--query-compute-apps=pid,used_memory",
+                    "--format=csv,noheader,nounits",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=2.0,
             )
             for line in result.stdout.splitlines():
                 parts = [part.strip() for part in line.split(",")]
@@ -257,49 +372,44 @@ def gpu_snapshot(pid: int | None = None) -> dict[str, Any]:
 
 
 def _yaml_scalar(path: Path, key: str) -> str | None:
-    try:
-        contents = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
-    match = re.search(rf"^\s*{re.escape(key)}:\s*([^#]+?)\s*$", contents, re.MULTILINE)
-    return match.group(1).strip().strip("\"'") if match else None
-
-
-def _yaml_nested_scalar(path: Path, parent: str, key: str) -> str | None:
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return None
-    parent_indent: int | None = None
-    parent_re = re.compile(rf"^(\s*){re.escape(parent)}:\s*(?:#.*)?$")
-    key_re = re.compile(rf"^(\s*){re.escape(key)}:\s*([^#]+?)\s*$")
-    for line in lines:
-        if parent_indent is None:
-            match = parent_re.match(line)
-            if match:
-                parent_indent = len(match.group(1))
-            continue
-        indent = len(line) - len(line.lstrip())
-        if line.strip() and indent <= parent_indent:
-            parent_indent = None
-            continue
-        match = key_re.match(line)
-        if match and len(match.group(1)) > parent_indent:
-            return match.group(2).strip().strip("\"'")
-    return None
+    return _yaml_path_scalar(path, (key,))
 
 
 def _sim_timestep(run_dir: Path) -> float | None:
     for name in ("env.yaml", "env_cfg.yaml", "environment.yaml"):
         path = run_dir / "params" / name
-        for parent in ("sim", "simulation"):
-            value = _yaml_nested_scalar(path, parent, "dt") if path.is_file() else None
+        if not path.is_file():
+            continue
+        for keys in (
+            ("sim", "mujoco", "timestep"),
+            ("sim", "dt"),
+            ("simulation", "dt"),
+        ):
+            value = _yaml_path_scalar(path, keys)
             if value is not None:
                 try:
                     return float(value)
                 except ValueError:
                     pass
     return None
+
+
+def _runtime_metadata(run_dir: Path, root: Path) -> dict[str, Any]:
+    log_path = monitor.training_log_path(run_dir, root)
+    metadata: dict[str, Any] = {}
+    for line in monitor.tail_lines(log_path, 4000):
+        runtime = TRAINING_RUNTIME_RE.search(line)
+        if runtime:
+            metadata["device"] = runtime.group(1)
+            try:
+                metadata["seed"] = int(runtime.group(2))
+            except ValueError:
+                metadata["seed"] = runtime.group(2)
+            metadata["rank"] = int(runtime.group(3))
+        world = GPU_WORLD_RE.search(line)
+        if world:
+            metadata["gpu_world_size"] = int(world.group(1))
+    return metadata
 
 
 def _latest_checkpoint(run_dir: Path) -> str | None:
@@ -309,6 +419,7 @@ def _latest_checkpoint(run_dir: Path) -> str | None:
         candidates.extend(checkpoint_dir.rglob("*.pt"))
     if not candidates:
         return None
+
     def key(path: Path) -> tuple[int, float]:
         match = CHECKPOINT_RE.search(path.stem)
         try:
@@ -316,6 +427,7 @@ def _latest_checkpoint(run_dir: Path) -> str | None:
         except OSError:
             modified = 0.0
         return (int(match.group(1)) if match else -1, modified)
+
     return max(candidates, key=key).relative_to(run_dir).as_posix()
 
 
@@ -351,11 +463,13 @@ def _first(sources: tuple[dict[str, Any], ...], *keys: str) -> Any:
 def build_run_info(run_dir: Path, root: Path, stage: str) -> dict[str, Any]:
     status = _json(run_status_path(run_dir, root)) or {}
     manifest = _json(run_dir / "training_manifest.json") or {}
+    runtime = _runtime_metadata(run_dir, root)
     git_data = _first((status, manifest), "git")
     git_data = git_data if isinstance(git_data, dict) else {}
     agent = run_dir / "params" / "agent.yaml"
     env = run_dir / "params" / "env.yaml"
-    seed = _first((status, manifest), "seed")
+
+    seed = _first((status, manifest, runtime), "seed")
     if seed is None and agent.is_file():
         raw = _yaml_scalar(agent, "seed")
         if raw is not None:
@@ -363,23 +477,31 @@ def build_run_info(run_dir: Path, root: Path, stage: str) -> dict[str, Any]:
                 seed = int(raw)
             except ValueError:
                 seed = raw
-    device = _first((status, manifest), "device")
+
+    device = _first((status, manifest, runtime), "device")
     if device is None:
         for path in (agent, env):
             raw = _yaml_scalar(path, "device") if path.is_file() else None
             if raw:
                 device = raw
                 break
+
     sim_timestep = _first((status, manifest), "simulation_timestep", "sim_timestep", "sim_dt")
     if sim_timestep is None:
         sim_timestep = _sim_timestep(run_dir)
+
     return {
         "git_commit": _first((status, manifest, git_data), "git_commit", "commit", "sha"),
         "git_branch": _first((status, manifest, git_data), "git_branch", "branch"),
-        "task": _first((status, manifest), "task"), "stage": stage, "seed": seed,
+        "task": _first((status, manifest), "task"),
+        "stage": stage,
+        "seed": seed,
         "command": _first((status, manifest), "command", "command_line"),
-        "simulation_timestep": sim_timestep, "device": device,
-        "checkpoint_path": _first((status, manifest), "checkpoint_path", "model_path") or _latest_checkpoint(run_dir),
+        "simulation_timestep": sim_timestep,
+        "device": device,
+        "gpu_world_size": _first((status, manifest, runtime), "gpu_world_size"),
+        "checkpoint_path": _first((status, manifest), "checkpoint_path", "model_path")
+        or _latest_checkpoint(run_dir),
         "model_path": _first((status, manifest), "model_path"),
         "configuration_files": _configuration_files(run_dir),
         "started_at": _first((status, manifest), "started_at", "start_time"),
@@ -409,7 +531,12 @@ def training_health(records: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def summarize_dashboard_run(
-    run_dir: Path, root: Path, *, stale_after_seconds: float = 90.0, detailed: bool = False, now: float | None = None
+    run_dir: Path,
+    root: Path,
+    *,
+    stale_after_seconds: float = 90.0,
+    detailed: bool = False,
+    now: float | None = None,
 ) -> dict[str, Any]:
     now = time.time() if now is None else now
     base = monitor.summarize_run(run_dir, root, now=now)
@@ -419,31 +546,48 @@ def summarize_dashboard_run(
     status = _json(status_file) or base.get("status") or {}
     modified_at = float(base.get("modified_at") or 0.0)
     wall = latest.get("wall_time") if latest else None
-    freshness = max(0.0, now - float(wall)) if _finite(wall) else max(0.0, now - modified_at)
+    freshness = (
+        max(0.0, now - float(wall))
+        if _finite(wall)
+        else max(0.0, now - modified_at)
+    )
     state = status.get("state") or base.get("state") or "unknown"
     if latest is not None:
         started = _timestamp(status.get("started_at"))
         event_time = _timestamp(latest.get("wall_time"))
         if started is not None and event_time is not None:
             latest["elapsed_seconds"] = max(0.0, event_time - started)
-    process = process_status(status.get("pid"))
+
+    process = process_status(status.get("pid"), status.get("pid_namespace"))
     stale = state in {"starting", "running"} and freshness > stale_after_seconds
     if state == "running" and process["alive"] is False:
         stale = True
-    base.update({
-        "state": state, "status": status, "telemetry": latest,
-        "stale": stale, "stale_after_seconds": stale_after_seconds,
-        "freshness_seconds": freshness, "process": process,
-        "status_source": status_file.relative_to(root).as_posix() if status_file.is_file() and _inside(status_file, root) else None,
-    })
+
+    base.update(
+        {
+            "state": state,
+            "status": status,
+            "telemetry": latest,
+            "stale": stale,
+            "stale_after_seconds": stale_after_seconds,
+            "freshness_seconds": freshness,
+            "process": process,
+            "status_source": status_file.relative_to(root).as_posix()
+            if status_file.is_file() and _inside(status_file, root)
+            else None,
+        }
+    )
     if detailed:
         base["training_health"] = training_health(records)
         base["run_info"] = build_run_info(run_dir, root, str(base.get("stage") or "unknown"))
-        base["system"] = gpu_snapshot(status.get("pid"))
+        process_pid = status.get("pid") if process.get("same_namespace") is not False else None
+        base["system"] = gpu_snapshot(process_pid)
     return base
 
 
-def list_dashboard_summaries(root: Path, *, stale_after_seconds: float = 90.0) -> list[dict[str, Any]]:
+def list_dashboard_summaries(
+    root: Path, *, stale_after_seconds: float = 90.0
+) -> list[dict[str, Any]]:
     return [
         summarize_dashboard_run(ref.path, root, stale_after_seconds=stale_after_seconds)
         for ref in discover_dashboard_runs(root)

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -11,6 +12,11 @@ from pathlib import Path
 from typing import Any
 
 from dashboard.config import REPO_ROOT, load_config
+
+TRAINING_RUNTIME_RE = re.compile(
+    r"Training with:\s*device=([^,\s]+),\s*seed=([^,\s]+),\s*rank=(\d+)"
+)
+GPU_WORLD_RE = re.compile(r"Launching training with\s+(\d+)\s+GPUs?", re.IGNORECASE)
 
 
 def write_status(path: Path, **values: Any) -> None:
@@ -47,6 +53,13 @@ def _repository_env(name: str) -> str | None:
     if not value or value.strip().lower() in {"unknown", "none", "null"}:
         return None
     return value.strip()
+
+
+def _pid_namespace() -> str | None:
+    try:
+        return os.readlink("/proc/self/ns/pid")
+    except OSError:
+        return None
 
 
 def git_metadata() -> dict[str, Any]:
@@ -93,6 +106,19 @@ def _number(value: str | None) -> int | float | str | None:
             return float(value)
         except ValueError:
             return value
+
+
+def _runtime_status_from_line(line: str) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    runtime = TRAINING_RUNTIME_RE.search(line)
+    if runtime:
+        values["device"] = runtime.group(1)
+        values["seed"] = _number(runtime.group(2))
+        values["rank"] = int(runtime.group(3))
+    world = GPU_WORLD_RE.search(line)
+    if world:
+        values["gpu_world_size"] = int(world.group(1))
+    return values
 
 
 def _latest_checkpoint(run_dir: Path) -> str | None:
@@ -178,6 +204,7 @@ def main() -> int:
     sim_timestep = _number(
         _training_arg(
             training_args,
+            "--env.sim.mujoco.timestep",
             "--env.sim.dt",
             "--sim.dt",
             "--simulation.dt",
@@ -188,7 +215,7 @@ def main() -> int:
 
     write_status(
         status_path,
-        schema_version=2,
+        schema_version=3,
         state="starting",
         task=args.task,
         stage=stage,
@@ -204,6 +231,7 @@ def main() -> int:
         git=git,
         git_commit=git.get("commit"),
         git_branch=git.get("branch"),
+        pid_namespace=_pid_namespace(),
         exit_code=None,
     )
 
@@ -240,6 +268,9 @@ def main() -> int:
                     sys.stdout.write(line)
                     sys.stdout.flush()
                     log.write(line)
+                    runtime_values = _runtime_status_from_line(line)
+                    if runtime_values:
+                        write_status(status_path, **runtime_values)
                 exit_code = process.wait()
             except KeyboardInterrupt:
                 process.terminate()

--- a/src/ascento_mjlab/mdp/rewards.py
+++ b/src/ascento_mjlab/mdp/rewards.py
@@ -18,7 +18,11 @@ def alive(env: ManagerBasedRlEnv) -> torch.Tensor:
   return (~env.termination_manager.terminated).float()
 
 
-def upright(env: ManagerBasedRlEnv, std: float = 0.35, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG) -> torch.Tensor:
+def upright(
+  env: ManagerBasedRlEnv,
+  std: float = 0.35,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
   asset: Entity = env.scene[asset_cfg.name]
   tilt_sq = torch.sum(torch.square(asset.data.projected_gravity_b[:, :2]), dim=1)
   return torch.exp(-tilt_sq / (std * std))
@@ -40,6 +44,14 @@ def angular_rate_penalty(
 ) -> torch.Tensor:
   asset: Entity = env.scene[asset_cfg.name]
   return torch.sum(torch.square(asset.data.root_link_ang_vel_b[:, :2]), dim=1)
+
+
+def planar_speed_penalty(
+  env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
+) -> torch.Tensor:
+  """Penalize horizontal drift while still allowing wheel motion for recovery."""
+  asset: Entity = env.scene[asset_cfg.name]
+  return torch.sum(torch.square(asset.data.root_link_lin_vel_b[:, :2]), dim=1)
 
 
 def effort_penalty(

--- a/src/ascento_mjlab/ppo.py
+++ b/src/ascento_mjlab/ppo.py
@@ -1,0 +1,53 @@
+"""Ascento PPO instrumentation built on the pinned RSL-RL implementation.
+
+RSL-RL uses KL internally for its adaptive learning-rate schedule but does not
+emit KL or clip fraction in its default loss dictionary.  This subclass keeps
+the upstream optimizer/update implementation intact, then evaluates the final
+updated policy against the rollout policy to expose stable full-rollout
+post-update diagnostics to TensorBoard.
+"""
+
+from __future__ import annotations
+
+import torch
+from rsl_rl.algorithms import PPO
+
+
+class InstrumentedPPO(PPO):
+  """PPO with post-update KL and clip-fraction telemetry."""
+
+  def update(self) -> dict[str, float]:
+    loss_dict = super().update()
+
+    # RolloutStorage.clear() only resets the write cursor; the rollout tensors
+    # remain valid until the next collection phase.  Evaluate the newly updated
+    # actor against those old-policy samples without changing optimizer state.
+    with torch.inference_mode():
+      observations = self.storage.observations.flatten(0, 1)
+      actions = self.storage.actions.flatten(0, 1)
+      old_log_prob = self.storage.actions_log_prob.flatten(0, 1).squeeze(-1)
+      old_distribution_params = tuple(
+        parameter.flatten(0, 1) for parameter in self.storage.distribution_params
+      )
+
+      self.actor(observations, stochastic_output=True)
+      new_log_prob = self.actor.get_output_log_prob(actions)
+      new_distribution_params = self.actor.output_distribution_params
+
+      ratio = torch.exp(new_log_prob - old_log_prob)
+      clip_fraction = torch.mean(
+        ((ratio < (1.0 - self.clip_param)) | (ratio > (1.0 + self.clip_param))).float()
+      )
+      kl = torch.mean(
+        self.actor.get_kl_divergence(old_distribution_params, new_distribution_params)
+      )
+
+      if self.is_multi_gpu:
+        torch.distributed.all_reduce(kl, op=torch.distributed.ReduceOp.SUM)
+        torch.distributed.all_reduce(clip_fraction, op=torch.distributed.ReduceOp.SUM)
+        kl /= self.gpu_world_size
+        clip_fraction /= self.gpu_world_size
+
+    loss_dict["kl"] = float(kl.item())
+    loss_dict["clip_fraction"] = float(clip_fraction.item())
+    return loss_dict

--- a/src/ascento_mjlab/tasks/balance/env_cfg.py
+++ b/src/ascento_mjlab/tasks/balance/env_cfg.py
@@ -82,7 +82,12 @@ def _observations(play: bool) -> dict[str, ObservationGroupCfg]:
       clip=(0.0, 2000.0),
       scale=0.01,
     ),
-    "effort": ObservationTermCfg(func=ascento_mdp.observations.actuator_effort, params={"asset_cfg": ROBOT_CFG}, clip=(-40.0, 40.0), scale=0.025),
+    "effort": ObservationTermCfg(
+      func=ascento_mdp.observations.actuator_effort,
+      params={"asset_cfg": ROBOT_CFG},
+      clip=(-40.0, 40.0),
+      scale=0.025,
+    ),
     "actions": ObservationTermCfg(func=mdp.last_action),
   }
   critic_terms = {
@@ -103,7 +108,10 @@ def _actions() -> dict[str, ActionTermCfg]:
       entity_name="robot",
       actuator_names=JOINT_NAMES,
       scale=40.0,
-      clip={".*": (-1.0, 1.0)},
+      # JointEffortActionCfg clips *after* scale/offset.  The physical target
+      # therefore needs a +/-40 Nm clamp; using +/-1 here silently reduces the
+      # robot to +/-1 Nm despite the 40 Nm action scale.
+      clip={".*": (-40.0, 40.0)},
       preserve_order=True,
     )
   }
@@ -129,30 +137,80 @@ def ascento_balance_env_cfg(play: bool = False, num_envs: int = 512) -> ManagerB
         func=ascento_mdp.events.reset_root_state_uniform,
         mode="reset",
         params={
-          "pose_range": {"x": (-0.02, 0.02), "y": (-0.02, 0.02), "z": (0.0, 0.0), "roll": (-0.08, 0.08), "pitch": (-0.08, 0.08), "yaw": (-3.14159, 3.14159)},
-          "velocity_range": {"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (-0.05, 0.05), "roll": (-0.1, 0.1), "pitch": (-0.1, 0.1), "yaw": (-0.1, 0.1)},
+          "pose_range": {
+            "x": (-0.02, 0.02),
+            "y": (-0.02, 0.02),
+            "z": (0.0, 0.0),
+            "roll": (-0.08, 0.08),
+            "pitch": (-0.08, 0.08),
+            "yaw": (-3.14159, 3.14159),
+          },
+          "velocity_range": {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (-0.05, 0.05),
+            "roll": (-0.1, 0.1),
+            "pitch": (-0.1, 0.1),
+            "yaw": (-0.1, 0.1),
+          },
           "asset_cfg": ROBOT_CFG,
         },
       ),
     },
     rewards={
       "alive": RewardTermCfg(func=ascento_mdp.rewards.alive, weight=1.0),
-      "upright": RewardTermCfg(func=ascento_mdp.rewards.upright, weight=2.0, params={"std": 0.35, "asset_cfg": ROBOT_CFG}),
-      "height": RewardTermCfg(func=ascento_mdp.rewards.height_tracking, weight=1.0, params={"target": 0.75, "std": 0.08, "asset_cfg": ROBOT_CFG}),
-      "angular_rate": RewardTermCfg(func=ascento_mdp.rewards.angular_rate_penalty, weight=-0.04, params={"asset_cfg": ROBOT_CFG}),
-      "effort": RewardTermCfg(func=ascento_mdp.rewards.effort_penalty, weight=-0.0005, params={"asset_cfg": ROBOT_CFG}),
+      "upright": RewardTermCfg(
+        func=ascento_mdp.rewards.upright,
+        weight=2.0,
+        params={"std": 0.35, "asset_cfg": ROBOT_CFG},
+      ),
+      "height": RewardTermCfg(
+        func=ascento_mdp.rewards.height_tracking,
+        weight=1.0,
+        params={"target": 0.75, "std": 0.08, "asset_cfg": ROBOT_CFG},
+      ),
+      "angular_rate": RewardTermCfg(
+        func=ascento_mdp.rewards.angular_rate_penalty,
+        weight=-0.04,
+        params={"asset_cfg": ROBOT_CFG},
+      ),
+      # Balance should be stationary on average.  This is deliberately mild:
+      # wheel translation remains available for recovery, but persistent drift
+      # is no longer reward-equivalent to balancing in place.
+      "planar_speed": RewardTermCfg(
+        func=ascento_mdp.rewards.planar_speed_penalty,
+        weight=-0.2,
+        params={"asset_cfg": ROBOT_CFG},
+      ),
+      "effort": RewardTermCfg(
+        func=ascento_mdp.rewards.effort_penalty,
+        weight=-0.0005,
+        params={"asset_cfg": ROBOT_CFG},
+      ),
       "action_rate": RewardTermCfg(func=ascento_mdp.rewards.action_rate_penalty, weight=-0.02),
     },
     terminations={
-      "fallen": TerminationTermCfg(func=ascento_mdp.terminations.fallen, params={"asset_cfg": ROBOT_CFG}),
-      "excessive_velocity": TerminationTermCfg(func=ascento_mdp.terminations.excessive_velocity, params={"asset_cfg": ROBOT_CFG}),
-      "nonfinite": TerminationTermCfg(func=ascento_mdp.terminations.nonfinite, params={"asset_cfg": ROBOT_CFG}),
+      "fallen": TerminationTermCfg(
+        func=ascento_mdp.terminations.fallen, params={"asset_cfg": ROBOT_CFG}
+      ),
+      "excessive_velocity": TerminationTermCfg(
+        func=ascento_mdp.terminations.excessive_velocity, params={"asset_cfg": ROBOT_CFG}
+      ),
+      "nonfinite": TerminationTermCfg(
+        func=ascento_mdp.terminations.nonfinite, params={"asset_cfg": ROBOT_CFG}
+      ),
       "time_out": TerminationTermCfg(func=mdp.time_out, time_out=True),
     },
     metrics={
-      "tilt_radians": MetricsTermCfg(func=ascento_mdp.metrics.tilt_radians, params={"asset_cfg": ROBOT_CFG}),
-      "applied_effort": MetricsTermCfg(func=ascento_mdp.metrics.applied_effort, params={"asset_cfg": ROBOT_CFG}),
-      "root_speed": MetricsTermCfg(func=ascento_mdp.metrics.root_speed, params={"asset_cfg": ROBOT_CFG}),
+      "tilt_radians": MetricsTermCfg(
+        func=ascento_mdp.metrics.tilt_radians, params={"asset_cfg": ROBOT_CFG}
+      ),
+      "applied_effort": MetricsTermCfg(
+        func=ascento_mdp.metrics.applied_effort, params={"asset_cfg": ROBOT_CFG}
+      ),
+      "root_speed": MetricsTermCfg(
+        func=ascento_mdp.metrics.root_speed, params={"asset_cfg": ROBOT_CFG}
+      ),
     },
     episode_length_s=20.0 if not play else 10000.0,
     auto_reset=True,

--- a/src/ascento_mjlab/tasks/balance/rl_cfg.py
+++ b/src/ascento_mjlab/tasks/balance/rl_cfg.py
@@ -19,6 +19,7 @@ AscentoBalanceRlCfg = RslRlOnPolicyRunnerCfg(
     lam=0.95,
     entropy_coef=0.005,
     max_grad_norm=1.0,
+    class_name="ascento_mjlab.ppo:InstrumentedPPO",
   ),
   logger="tensorboard",
   experiment_name="ascento_balance",
@@ -27,4 +28,5 @@ AscentoBalanceRlCfg = RslRlOnPolicyRunnerCfg(
   num_steps_per_env=24,
   save_interval=250,
   max_iterations=10_000,
+  clip_actions=1.0,
 )

--- a/tests_dashboard/test_config_launch.py
+++ b/tests_dashboard/test_config_launch.py
@@ -4,7 +4,7 @@ import pytest
 
 import dashboard.launch as launch
 from dashboard.config import load_config, validate_startup
-from dashboard.launch import _training_arg, build_parser
+from dashboard.launch import _runtime_status_from_line, _training_arg, build_parser
 
 
 def test_launcher_uses_same_default_artifact_root_as_dashboard(monkeypatch, tmp_path):
@@ -20,7 +20,7 @@ def test_launcher_argument_metadata_parser_supports_both_cli_forms():
         "--seed=7",
         "--device",
         "cuda:0",
-        "--env.sim.dt",
+        "--env.sim.mujoco.timestep",
         "0.002",
         "--agent.seed",
         "11",
@@ -28,7 +28,16 @@ def test_launcher_argument_metadata_parser_supports_both_cli_forms():
 
     assert _training_arg(args, "--seed", "--agent.seed") == "11"
     assert _training_arg(args, "--device") == "cuda:0"
-    assert _training_arg(args, "--env.sim.dt") == "0.002"
+    assert _training_arg(args, "--env.sim.mujoco.timestep") == "0.002"
+
+
+def test_launcher_extracts_runtime_device_seed_and_world_size():
+    assert _runtime_status_from_line(
+        "[INFO] Training with: device=cuda:0, seed=42, rank=0"
+    ) == {"device": "cuda:0", "seed": 42, "rank": 0}
+    assert _runtime_status_from_line("[INFO] Launching training with 2 GPUs") == {
+        "gpu_world_size": 2
+    }
 
 
 def test_launcher_uses_injected_repository_version_without_git(monkeypatch):

--- a/tests_dashboard/test_monitor.py
+++ b/tests_dashboard/test_monitor.py
@@ -2,9 +2,11 @@ import json
 import os
 
 from dashboard.health import (
+    _pid_namespace,
     decorate_records,
     discover_dashboard_runs,
     load_dashboard_records,
+    process_status,
     summarize_dashboard_run,
 )
 
@@ -17,9 +19,11 @@ def test_canonical_metrics_and_non_finite_detection(tmp_path):
                 "Train/mean_reward": 2.5,
                 "Train/mean_episode_length": 42.0,
                 "Loss/surrogate": 0.12,
+                "Loss/value": 0.003,
                 "Loss/entropy": -0.02,
                 "Loss/kl": 0.006,
-                "Policy/clip_fraction": 0.17,
+                "Loss/clip_fraction": 0.17,
+                "Loss/learning_rate": 1.5e-4,
                 "bad_metric": float("inf"),
             },
         }],
@@ -29,8 +33,12 @@ def test_canonical_metrics_and_non_finite_detection(tmp_path):
     assert record["canonical_metrics"]["reward"] == 2.5
     assert record["canonical_metrics"]["episode_length"] == 42.0
     assert record["canonical_metrics"]["ppo_loss"] == 0.12
+    assert record["canonical_metrics"]["value_loss"] == 0.003
     assert record["canonical_metrics"]["kl"] == 0.006
     assert record["canonical_metrics"]["clip_fraction"] == 0.17
+    assert record["canonical_metrics"]["learning_rate"] == 1.5e-4
+    assert record["completed_iterations"] == 3
+    assert "completed_steps" not in record
     assert record["metrics"]["bad_metric"] is None
     assert record["has_non_finite"] is True
     assert record["canonical_metrics"]["invalid_update"] == 1
@@ -40,18 +48,22 @@ def test_nested_launcher_run_is_discovered_once_and_inherits_metadata(tmp_path):
     launch_dir = tmp_path / "20260903_balance"
     actual_run = launch_dir / "ascento_balance" / "2026-09-03_13-00-00"
     actual_run.mkdir(parents=True)
-    (launch_dir / "training.log").write_text("training\n", encoding="utf-8")
+    (launch_dir / "training.log").write_text(
+        "[INFO] Training with: device=cuda:0, seed=12, rank=0\n",
+        encoding="utf-8",
+    )
     (launch_dir / "run_status.json").write_text(
         json.dumps(
             {
                 "state": "running",
                 "task": "Ascento-Balance-Flat",
                 "stage": "balance",
-                "seed": 12,
-                "device": "cuda:0",
-                "started_at": "2026-09-03T11:00:00+00:00",
+                "seed": None,
+                "device": None,
+                "started_at": "1970-01-01T00:13:20+00:00",
                 "command": ["python", "-m", "mjlab.scripts.train"],
                 "pid": os.getpid(),
+                "pid_namespace": _pid_namespace(),
                 "git_commit": "abc123",
                 "git_branch": "feature/test",
             }
@@ -60,8 +72,14 @@ def test_nested_launcher_run_is_discovered_once_and_inherits_metadata(tmp_path):
     )
     params = actual_run / "params"
     params.mkdir()
-    (params / "agent.yaml").write_text("max_iterations: 100\n", encoding="utf-8")
-    (params / "env.yaml").write_text("sim:\n  dt: 0.002\n", encoding="utf-8")
+    (params / "agent.yaml").write_text(
+        "max_iterations: 100\nnum_steps_per_env: 24\nseed: 42\n",
+        encoding="utf-8",
+    )
+    (params / "env.yaml").write_text(
+        "scene:\n  num_envs: 512\nsim:\n  mujoco:\n    timestep: 0.002\n",
+        encoding="utf-8",
+    )
     (actual_run / "model_20.pt").write_bytes(b"")
     (actual_run / "telemetry.jsonl").write_text(
         "\n".join(
@@ -115,11 +133,26 @@ def test_nested_launcher_run_is_discovered_once_and_inherits_metadata(tmp_path):
     assert summary["run_info"]["git_commit"] == "abc123"
     assert summary["run_info"]["task"] == "Ascento-Balance-Flat"
     assert summary["run_info"]["seed"] == 12
+    assert summary["run_info"]["device"] == "cuda:0"
     assert summary["run_info"]["simulation_timestep"] == 0.002
     assert summary["run_info"]["checkpoint_path"] == "model_20.pt"
     assert summary["training_health"]["invalid_updates"] == 1
     assert summary["telemetry"]["iteration"] == 20
+    assert summary["telemetry"]["completed_iterations"] == 20
+    assert summary["telemetry"]["environment_steps"] == 20 * 24 * 512
+    assert summary["telemetry"]["total_environment_steps"] == 100 * 24 * 512
+    assert summary["telemetry"]["environment_steps_per_second"] == 5200.0
+    assert "completed_steps" not in summary["telemetry"]
+    assert "total_steps" not in summary["telemetry"]
     assert summary["telemetry"]["eta_seconds"] == 80.0
+
+
+def test_cross_namespace_pid_is_not_reported_alive():
+    result = process_status(os.getpid(), "pid:[definitely-not-this-namespace]")
+
+    assert result["alive"] is None
+    assert result["same_namespace"] is False
+    assert result["reason"] == "different_pid_namespace"
 
 
 def test_jsonl_eta_uses_iteration_rate_not_environment_fps(tmp_path):
@@ -151,6 +184,7 @@ def test_jsonl_eta_uses_iteration_rate_not_environment_fps(tmp_path):
     )
 
     records = load_dashboard_records(run_dir)
-    assert records[-1]["steps_per_second"] == 100000.0
+    assert records[-1]["environment_steps_per_second"] == 100000.0
+    assert "steps_per_second" not in records[-1]
     assert records[-1]["iterations_per_second"] == 1.0
     assert records[-1]["eta_seconds"] == 90.0

--- a/tests_mjlab/test_task_config.py
+++ b/tests_mjlab/test_task_config.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from mjlab.envs import ManagerBasedRlEnv
-from mjlab.tasks.registry import load_env_cfg
+from mjlab.tasks.registry import load_env_cfg, load_rl_cfg
 
 import ascento_mjlab.tasks  # noqa: F401
 
@@ -21,6 +21,30 @@ def test_balance_env_is_six_effort_flat_ground():
   assert torch.isfinite(reward).all()
   assert not terminated.any()
   assert terminated.shape == truncated.shape == (cfg.scene.num_envs,)
+  env.close()
+
+
+def test_balance_action_contract_reaches_40_nm_and_penalizes_drift():
+  cfg = load_env_cfg("Ascento-Balance-Flat")
+  cfg.scene.num_envs = 1
+
+  action_cfg = cfg.actions["effort"]
+  assert action_cfg.scale == 40.0
+  assert action_cfg.clip == {".*": (-40.0, 40.0)}
+  assert cfg.rewards["planar_speed"].weight == pytest.approx(-0.2)
+
+  env = ManagerBasedRlEnv(cfg, device="cpu")
+  env.action_manager.process_action(torch.ones((1, 6)))
+  action_term = env.action_manager.get_term("effort")
+  assert torch.allclose(action_term._processed_actions, torch.full((1, 6), 40.0))
+  env.close()
+
+
+def test_balance_rl_config_enforces_normalized_actions_and_instrumented_ppo():
+  cfg = load_rl_cfg("Ascento-Balance-Flat")
+
+  assert cfg.clip_actions == 1.0
+  assert cfg.algorithm.class_name == "ascento_mjlab.ppo:InstrumentedPPO"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fix the correctness problems found while auditing the first long `Ascento-Balance-Flat` run.

### Plant / task correctness

- restore the intended normalized-action -> +/-40 Nm effort contract
  - RSL-RL now clips policy actions to `[-1, 1]`
  - mjlab's post-scale effort clamp is corrected from `[-1, 1] Nm` to `[-40, 40] Nm`
- add a mild planar root-speed penalty so stationary balance is preferred over rolling away while upright
- add regression tests that verify a +1 normalized action becomes a +40 Nm processed effort target

### PPO observability

- add `InstrumentedPPO`, a thin subclass of the pinned RSL-RL PPO implementation
- keep the upstream optimizer/update implementation unchanged
- after each update, evaluate the final policy against the retained rollout tensors and emit full-rollout post-update:
  - KL divergence
  - clip fraction
- retain the existing balance PPO hyperparameters

### Dashboard / run metadata correctness

- recognize RSL-RL's actual `Loss/value` TensorBoard metric
- expose learning-rate telemetry canonically
- stop presenting PPO iterations as `completed_steps` / `total_steps`
- expose explicit iteration fields and environment-step throughput/transition totals
- recover device and seed from the trainer's runtime output
- read the actual mjlab YAML path `sim.mujoco.timestep`
- record the launcher's PID namespace and avoid claiming a PID is alive when the dashboard is running in another container namespace
- avoid trying to attribute GPU process memory to a PID from another namespace

### Documentation / tests

- correct the mjlab 1.6 CLI example from `--num-envs` to `--env.scene.num-envs`
- document the normalized action / 40 Nm physical contract
- add dashboard regression coverage for units, value loss, runtime metadata, realistic env YAML, and PID namespaces

## Why

The audited run showed ~0.915 Nm mean absolute effort despite a nominal 40 Nm actuator profile. The root cause was mjlab applying `JointEffortActionCfg.clip` *after* `scale`, so `scale=40` combined with `clip=(-1, 1)` silently limited requested effort to +/-1 Nm. The same audit also found ~0.74 m/s root drift was not penalized and several dashboard fields were either missing or unit-mislabeled.

## Validation

CI should run both `tests_mjlab` and `tests_dashboard` because this PR changes both test trees. The most important new regression is an environment-level assertion that normalized action `+1` produces a processed `+40 Nm` target.