### PR TITLE
Fix maintenance provenance import on direct script execution

### DIFF
--- a/scripts/stamp_run_provenance.py
+++ b/scripts/stamp_run_provenance.py
@@ -3,8 +3,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+# This script is executed directly by scripts/maintain.sh. In that mode Python
+# puts ``scripts/`` (not the repository root) on sys.path, while ``dashboard``
+# is a top-level repository package rather than part of the installed src
+# package. Add the checkout root explicitly so a fresh/updated installation can
+# import the dashboard helpers without relying on the caller's working directory
+# or PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from dashboard.health import discover_dashboard_runs
 from dashboard.versioning import run_repository_provenance

--- a/tests_dashboard/test_stamp_run_provenance.py
+++ b/tests_dashboard/test_stamp_run_provenance.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "stamp_run_provenance.py"
+
+
+def test_stamp_run_provenance_runs_directly_without_pythonpath(tmp_path):
+    runs = tmp_path / "runs"
+    runs.mkdir()
+
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(runs),
+            "--commit",
+            "test-commit",
+            "--branch",
+            "main",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Stamped repository provenance for 0 legacy run(s)." in result.stdout


### PR DESCRIPTION
## Summary

Fix `scripts/maintain.sh` failing during legacy-run provenance backfill with:

```text
ModuleNotFoundError: No module named 'dashboard'
```

### Root cause

`maintain.sh` executes `scripts/stamp_run_provenance.py` directly by file path. In that execution mode Python adds the `scripts/` directory to `sys.path`, not the repository root. The provenance script imports the top-level `dashboard` package, which is intentionally not installed as part of the `src/` project package, so a normal fresh/updated environment cannot resolve the import.

### Fix

- make `stamp_run_provenance.py` explicitly add its checkout root to `sys.path` before importing dashboard helpers;
- add a regression test that launches the script from an unrelated working directory with `PYTHONPATH` removed, matching the failure mode seen in WSL maintenance.

This makes the provenance utility robust regardless of caller working directory and avoids relying on implicit environment path behavior.