### PR TITLE
Stabilize training and evaluation before long run

### DIFF
--- a/benchmarks/suites/velocity_gate_v1.toml
+++ b/benchmarks/suites/velocity_gate_v1.toml
@@ -3,7 +3,15 @@ suite_id = "velocity_gate_v1"
 task = "Ascento-Velocity-Flat"
 root_seed = 194427
 policy_mode = "deterministic"
-required_capabilities = ["velocity", "velocity_tracking", "command:twist", "exact_reset", "deterministic_policy"]
+required_capabilities = [
+  "velocity",
+  "velocity_tracking",
+  "height_tracking",
+  "command:twist",
+  "command:height",
+  "exact_reset",
+  "deterministic_policy",
+]
 
 [[families]]
 id = "step_tracking"
@@ -12,11 +20,15 @@ count = 512
 horizon_s = 20.0
 commands = [
   { time_s = 0.0, name = "twist", values = [0.0, 0.0, 0.0] },
+  { time_s = 0.0, name = "height", values = [0.75] },
   { time_s = 3.0, name = "twist", values = [0.25, 0.0, 0.0] },
+  { time_s = 5.0, name = "height", values = [0.70] },
   { time_s = 7.0, name = "twist", values = [0.0, 0.0, 0.0] },
   { time_s = 10.0, name = "twist", values = [-0.25, 0.0, 0.0] },
+  { time_s = 12.0, name = "height", values = [0.80] },
   { time_s = 14.0, name = "twist", values = [0.0, 0.0, 0.3] },
   { time_s = 18.0, name = "twist", values = [0.0, 0.0, 0.0] },
+  { time_s = 18.0, name = "height", values = [0.75] },
 ]
 [families.reset]
 roll = [-0.08, 0.08]
@@ -35,10 +47,15 @@ count = 512
 horizon_s = 20.0
 commands = [
   { time_s = 0.0, name = "twist", values = [0.0, 0.0, 0.0] },
+  { time_s = 0.0, name = "height", values = [0.75] },
   { time_s = 3.0, name = "twist", values = [0.4, 0.0, 0.4] },
+  { time_s = 3.0, name = "height", values = [0.70] },
   { time_s = 8.0, name = "twist", values = [-0.4, 0.0, -0.4] },
+  { time_s = 8.0, name = "height", values = [0.80] },
   { time_s = 13.0, name = "twist", values = [0.4, 0.0, -0.4] },
+  { time_s = 13.0, name = "height", values = [0.72] },
   { time_s = 18.0, name = "twist", values = [0.0, 0.0, 0.0] },
+  { time_s = 18.0, name = "height", values = [0.75] },
 ]
 [families.reset]
 roll = [-0.08, 0.08]
@@ -76,3 +93,19 @@ metric = "velocity_tracking_rmse"
 statistic = "p95"
 op = "<="
 threshold = 0.25
+
+[[gates]]
+id = "step_height_rmse_p95"
+family = "step_tracking"
+metric = "height_tracking_rmse"
+statistic = "p95"
+op = "<="
+threshold = 0.07
+
+[[gates]]
+id = "combined_height_rmse_p95"
+family = "combined"
+metric = "height_tracking_rmse"
+statistic = "p95"
+op = "<="
+threshold = 0.08

--- a/src/ascento_mjlab/actuator.py
+++ b/src/ascento_mjlab/actuator.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .physics import PHYSICS_PROFILE
+
 
 @dataclass(frozen=True)
 class ActuatorDocumentation:
@@ -25,8 +27,12 @@ class ActuatorDocumentation:
   response_time_s: float
 
 
-LEG_ACTUATOR = ActuatorDocumentation(40.0, 15.0, 12.0, 4.0, 0.004)
-WHEEL_ACTUATOR = ActuatorDocumentation(40.0, 5.0, 20.0, 10.0, 0.003)
+LEG_ACTUATOR = ActuatorDocumentation(
+  PHYSICS_PROFILE.peak_effort_nm, 15.0, 12.0, 4.0, 0.004
+)
+WHEEL_ACTUATOR = ActuatorDocumentation(
+  PHYSICS_PROFILE.peak_effort_nm, 5.0, 20.0, 10.0, 0.003
+)
 
 _LAZY_EXPORTS = {
   "AscentoTorqueActuator",

--- a/src/ascento_mjlab/actuator.py
+++ b/src/ascento_mjlab/actuator.py
@@ -1,24 +1,19 @@
-"""Ascento-specific direct-effort actuator model.
+"""Public Ascento actuator specification with lazy mjlab implementation loading.
 
-The model intentionally has no thermal or continuous-torque limiter.  The
-15 Nm leg and 5 Nm wheel values are documentation until duration-dependent
-thermal behavior is justified.  The initial simulation behavior is instead
-defined by peak torque, the linear torque-speed envelope, controller speed
-protection, and a finite torque-loop response.
+This module intentionally stays free of mjlab imports at import time. mjlab
+auto-discovers task entry points while it imports, and importing mjlab from this
+module before the actuator constants existed could re-enter Ascento task
+registration through ``robot_cfg`` and leave the registry empty.
+
+The actual actuator classes are loaded lazily from ``actuator_impl`` when a
+consumer asks for them. Existing imports from ``ascento_mjlab.actuator`` remain
+compatible while actuator-first imports are now safe.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-import mujoco
-import torch
-from mjlab.actuator import Actuator, ActuatorCfg, ActuatorCmd
-from mjlab.utils.spec import create_motor_actuator
-
-if TYPE_CHECKING:
-  from mjlab.entity import Entity
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -33,116 +28,28 @@ class ActuatorDocumentation:
 LEG_ACTUATOR = ActuatorDocumentation(40.0, 15.0, 12.0, 4.0, 0.004)
 WHEEL_ACTUATOR = ActuatorDocumentation(40.0, 5.0, 20.0, 10.0, 0.003)
 
-
-def torque_speed_limit(
-  peak_torque: float,
-  no_load_speed: float,
-  controller_speed_limit: float,
-  velocity: torch.Tensor,
-  requested: torch.Tensor,
-) -> torch.Tensor:
-  """Apply the transient torque-speed envelope and motoring speed guard."""
-  speed = torch.abs(velocity)
-  envelope = torch.clamp(1.0 - speed / no_load_speed, min=0.0)
-  output = torch.clamp(requested, -peak_torque * envelope, peak_torque * envelope)
-  over_speed = speed > controller_speed_limit
-  motoring = torch.sign(output) * velocity > 0.0
-  return torch.where(over_speed & motoring, torch.zeros_like(output), output)
+_LAZY_EXPORTS = {
+  "AscentoTorqueActuator",
+  "AscentoTorqueActuatorCfg",
+  "torque_speed_limit",
+}
 
 
-@dataclass(kw_only=True)
-class AscentoTorqueActuatorCfg(ActuatorCfg):
-  """Direct-effort actuator with motion-relevant transient limits only."""
+def __getattr__(name: str) -> Any:
+  if name not in _LAZY_EXPORTS:
+    raise AttributeError(name)
+  from . import actuator_impl
 
-  peak_torque: float
-  no_load_speed: float
-  controller_speed_limit: float
-  response_time: float
-
-  def __post_init__(self) -> None:
-    super().__post_init__()
-    if self.peak_torque <= 0.0:
-      raise ValueError("peak_torque must be positive")
-    if self.no_load_speed <= 0.0:
-      raise ValueError("no_load_speed must be positive")
-    if self.controller_speed_limit <= 0.0:
-      raise ValueError("controller_speed_limit must be positive")
-    if self.response_time < 0.0:
-      raise ValueError("response_time must be non-negative")
-
-  def build(
-    self, entity: Entity, target_ids: list[int], target_names: list[str]
-  ) -> AscentoTorqueActuator:
-    return AscentoTorqueActuator(self, entity, target_ids, target_names)
+  value = getattr(actuator_impl, name)
+  globals()[name] = value
+  return value
 
 
-class AscentoTorqueActuator(Actuator[AscentoTorqueActuatorCfg]):
-  """Stateful torque response with a one-sided high-speed motor guard."""
-
-  def __init__(
-    self,
-    cfg: AscentoTorqueActuatorCfg,
-    entity: Entity,
-    target_ids: list[int],
-    target_names: list[str],
-  ) -> None:
-    super().__init__(cfg, entity, target_ids, target_names)
-    self._filtered: torch.Tensor | None = None
-    self._physics_dt: float | None = None
-
-  def edit_spec(self, spec: mujoco.MjSpec, target_names: list[str]) -> None:
-    for target_name in target_names:
-      self._mjs_actuators.append(
-        create_motor_actuator(
-          spec,
-          target_name,
-          effort_limit=self.cfg.peak_torque,
-          transmission_type=self.cfg.transmission_type,
-        )
-      )
-
-  def initialize(
-    self,
-    mj_model: mujoco.MjModel,
-    model,
-    data,
-    device: str,
-  ) -> None:
-    # SimulationCfg is applied to the compiled model before Entity.initialize
-    # is called. Reading the model keeps this actuator tied to the active
-    # simulation, including task-specific timestep overrides.
-    self._physics_dt = float(mj_model.opt.timestep)
-    super().initialize(mj_model, model, data, device)
-    self._filtered = torch.zeros(
-      (data.nworld, len(self.target_ids)), dtype=torch.float32, device=device
-    )
-
-  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
-    assert self._filtered is not None
-    requested = torch.clamp(cmd.effort_target, -self.cfg.peak_torque, self.cfg.peak_torque)
-
-    # compute() runs once per physics substep in mjlab.  Use the exact
-    # discretization of a first-order torque loop, with the project timestep
-    # supplied by the active simulation configuration.
-    if self._physics_dt is None:
-      raise RuntimeError("Actuator must be initialized before compute()")
-    dt = self._physics_dt
-    alpha = 1.0 if self.cfg.response_time == 0.0 else 1.0 - torch.exp(
-      torch.tensor(-dt / self.cfg.response_time, device=requested.device)
-    )
-    self._filtered.add_(alpha * (requested - self._filtered))
-
-    # At the controller speed limit, remove only motoring torque. Braking
-    # torque remains available so the robot can decelerate rather than coast.
-    return torque_speed_limit(
-      self.cfg.peak_torque,
-      self.cfg.no_load_speed,
-      self.cfg.controller_speed_limit,
-      cmd.vel,
-      self._filtered,
-    )
-
-  def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
-    super().reset(env_ids)
-    assert self._filtered is not None
-    self._filtered[env_ids if env_ids is not None else slice(None)] = 0.0
+__all__ = [
+  "ActuatorDocumentation",
+  "LEG_ACTUATOR",
+  "WHEEL_ACTUATOR",
+  "AscentoTorqueActuator",
+  "AscentoTorqueActuatorCfg",
+  "torque_speed_limit",
+]

--- a/src/ascento_mjlab/actuator_impl.py
+++ b/src/ascento_mjlab/actuator_impl.py
@@ -1,0 +1,123 @@
+"""mjlab-dependent implementation of the Ascento actuator model.
+
+Kept separate from :mod:`ascento_mjlab.actuator` so importing the public
+actuator specification does not import mjlab while its entry-point task loader
+is still starting.  This avoids the actuator-first task-registration cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import mujoco
+import torch
+from mjlab.actuator import Actuator, ActuatorCfg, ActuatorCmd
+from mjlab.utils.spec import create_motor_actuator
+
+if TYPE_CHECKING:
+  from mjlab.entity import Entity
+
+
+def torque_speed_limit(
+  peak_torque: float,
+  no_load_speed: float,
+  controller_speed_limit: float,
+  velocity: torch.Tensor,
+  requested: torch.Tensor,
+) -> torch.Tensor:
+  """Apply the transient torque-speed envelope and motoring speed guard."""
+  speed = torch.abs(velocity)
+  envelope = torch.clamp(1.0 - speed / no_load_speed, min=0.0)
+  output = torch.clamp(requested, -peak_torque * envelope, peak_torque * envelope)
+  over_speed = speed > controller_speed_limit
+  motoring = torch.sign(output) * velocity > 0.0
+  return torch.where(over_speed & motoring, torch.zeros_like(output), output)
+
+
+@dataclass(kw_only=True)
+class AscentoTorqueActuatorCfg(ActuatorCfg):
+  """Direct-effort actuator with motion-relevant transient limits only."""
+
+  peak_torque: float
+  no_load_speed: float
+  controller_speed_limit: float
+  response_time: float
+
+  def __post_init__(self) -> None:
+    super().__post_init__()
+    if self.peak_torque <= 0.0:
+      raise ValueError("peak_torque must be positive")
+    if self.no_load_speed <= 0.0:
+      raise ValueError("no_load_speed must be positive")
+    if self.controller_speed_limit <= 0.0:
+      raise ValueError("controller_speed_limit must be positive")
+    if self.response_time < 0.0:
+      raise ValueError("response_time must be non-negative")
+
+  def build(
+    self, entity: Entity, target_ids: list[int], target_names: list[str]
+  ) -> AscentoTorqueActuator:
+    return AscentoTorqueActuator(self, entity, target_ids, target_names)
+
+
+class AscentoTorqueActuator(Actuator[AscentoTorqueActuatorCfg]):
+  """Stateful torque response with a one-sided high-speed motor guard."""
+
+  def __init__(
+    self,
+    cfg: AscentoTorqueActuatorCfg,
+    entity: Entity,
+    target_ids: list[int],
+    target_names: list[str],
+  ) -> None:
+    super().__init__(cfg, entity, target_ids, target_names)
+    self._filtered: torch.Tensor | None = None
+    self._physics_dt: float | None = None
+
+  def edit_spec(self, spec: mujoco.MjSpec, target_names: list[str]) -> None:
+    for target_name in target_names:
+      self._mjs_actuators.append(
+        create_motor_actuator(
+          spec,
+          target_name,
+          effort_limit=self.cfg.peak_torque,
+          transmission_type=self.cfg.transmission_type,
+        )
+      )
+
+  def initialize(
+    self,
+    mj_model: mujoco.MjModel,
+    model,
+    data,
+    device: str,
+  ) -> None:
+    self._physics_dt = float(mj_model.opt.timestep)
+    super().initialize(mj_model, model, data, device)
+    self._filtered = torch.zeros(
+      (data.nworld, len(self.target_ids)), dtype=torch.float32, device=device
+    )
+
+  def compute(self, cmd: ActuatorCmd) -> torch.Tensor:
+    assert self._filtered is not None
+    requested = torch.clamp(cmd.effort_target, -self.cfg.peak_torque, self.cfg.peak_torque)
+    if self._physics_dt is None:
+      raise RuntimeError("Actuator must be initialized before compute()")
+    dt = self._physics_dt
+    alpha = 1.0 if self.cfg.response_time == 0.0 else 1.0 - torch.exp(
+      torch.tensor(-dt / self.cfg.response_time, device=requested.device)
+    )
+    self._filtered.add_(alpha * (requested - self._filtered))
+    return torque_speed_limit(
+      self.cfg.peak_torque,
+      self.cfg.no_load_speed,
+      self.cfg.controller_speed_limit,
+      cmd.vel,
+      self._filtered,
+    )
+
+  def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+    super().reset(env_ids)
+    assert self._filtered is not None
+    self._filtered[env_ids if env_ids is not None else slice(None)] = 0.0

--- a/src/ascento_mjlab/evaluation/runner.py
+++ b/src/ascento_mjlab/evaluation/runner.py
@@ -33,13 +33,18 @@ def task_capabilities(task: str) -> set[str]:
   if "Balance" in task:
     capabilities.add("balance")
   if "Velocity" in task:
-    capabilities.update({"velocity", "command:twist", "velocity_tracking"})
+    capabilities.update(
+      {
+        "velocity",
+        "command:twist",
+        "command:height",
+        "velocity_tracking",
+        "height_tracking",
+      }
+    )
   if "Recovery" in task:
     capabilities.update({"recovery", "recovery_success"})
   if "Jump" in task:
-    # Current flat-jump state supports event diagnostics, but deliberately does
-    # not claim target-distance or true pre-impact metrics until those signals
-    # are implemented canonically.
     capabilities.update({"jump_events", "command:motion"})
   return capabilities
 
@@ -128,6 +133,36 @@ def _exact_reset(base_env: ManagerBasedRlEnv, scenarios: list[ScenarioSpec]) -> 
   return positions[:, :2].clone()
 
 
+def _refresh_exact_observation_history(base_env: ManagerBasedRlEnv) -> None:
+  """Seed stateful observation buffers from the exact scenario state only.
+
+  ``env.reset()`` must run first to reset managers, but it also writes a
+  stochastic training reset into history/delay buffers. After `_exact_reset`
+  overwrites that state, clear those buffers and seed them with the resolved
+  deterministic frame so history-dependent policies do not see a hidden random
+  pre-scenario observation.
+  """
+  env_ids = torch.arange(base_env.num_envs, device=base_env.device, dtype=torch.long)
+  base_env.observation_manager.reset(env_ids)
+  base_env.obs_buf = base_env.observation_manager.compute(
+    update_history=True, env_ids=env_ids
+  )
+
+
+def _reset_finished_slots(base_env: ManagerBasedRlEnv, policy, finish: torch.Tensor) -> None:
+  """Clear mjlab manual-reset state for completed vector slots.
+
+  mjlab 1.6 requires every done slot to be explicitly reset before the next
+  vector ``step()`` when ``auto_reset=False``. Horizon-complete slots are reset
+  too so all inactive slots have the same benign lifecycle.
+  """
+  if not bool(finish.any().item()):
+    return
+  env_ids = finish.nonzero(as_tuple=False).squeeze(-1)
+  base_env.reset(env_ids=env_ids)
+  policy.reset(env_ids)
+
+
 def _command_values_for_step(
   scenarios: list[ScenarioSpec], step: int
 ) -> dict[str, list[tuple[int, tuple[float, ...]]]]:
@@ -203,7 +238,11 @@ def _disturbance_wrench(
   }
   for env_id, scenario in enumerate(scenarios):
     for disturbance in scenario.disturbances:
-      if not (disturbance.start_step <= step < disturbance.start_step + disturbance.duration_steps):
+      if not (
+        disturbance.start_step
+        <= step
+        < disturbance.start_step + disturbance.duration_steps
+      ):
         continue
       duration_s = disturbance.duration_steps * step_dt
       magnitude = (
@@ -270,6 +309,7 @@ def _run_batch(
 
   env.reset()
   initial_xy = _exact_reset(base_env, scenarios)
+  _refresh_exact_observation_history(base_env)
   policy.reset()
   count = len(scenarios)
   dev = base_env.device
@@ -305,14 +345,13 @@ def _run_batch(
   airborne_count = torch.zeros(count, device=dev)
   path_length = torch.zeros(count, device=dev)
   sum_velocity_tracking_sq = torch.zeros(count, device=dev)
+  sum_height_tracking_sq = torch.zeros(count, device=dev)
   recovery_stable_count = torch.zeros(count, dtype=torch.long, device=dev)
   recovery_success = torch.zeros(count, dtype=torch.bool, device=dev)
   recovery_from_start_s = torch.full((count,), float("nan"), device=dev)
   prev_xy = initial_xy.clone()
   final_xy_snapshot = initial_xy.clone()
 
-  # Disturbance recovery envelope. This is deliberately stricter than the
-  # training reward and requires a continuous 0.5 s stable window.
   stable_count = torch.zeros(count, dtype=torch.long, device=dev)
   recovered = torch.zeros(count, dtype=torch.bool, device=dev)
   recovery_time = torch.full((count,), float("nan"), device=dev)
@@ -344,11 +383,14 @@ def _run_batch(
         if is_velocity_task
         else None
       )
+      height_target = (
+        _command_target(scenarios, step, name="height", dim=1, device=dev)
+        if is_velocity_task
+        else None
+      )
       forces, torques, wrench_active = _disturbance_wrench(
         scenarios, step, mass=mass, step_dt=step_dt, device=dev
       )
-      # Always write the root-body wrench so impulses are cleared exactly on
-      # schedule instead of relying on a later reset.
       if bool((wrench_active | last_wrench_active).any().item()):
         base_env.scene["robot"].write_external_wrench_to_sim(
           forces,
@@ -364,12 +406,10 @@ def _run_batch(
         raise RuntimeError("Policy emitted NaN/Inf action during evaluation")
 
       clip_limit = float(agent_cfg.clip_actions)
-      clipped = torch.clamp(raw_action, -clip_limit, clip_limit)
       clipped_fraction = (torch.abs(raw_action) > clip_limit).float().mean(dim=-1)
       action_clip_count += clipped_fraction * active.float()
       action_count += active.float()
 
-      # Keep inactive slots benign while the rest of the vector batch finishes.
       action = torch.where(active[:, None], raw_action, torch.zeros_like(raw_action))
       _, _, dones, _ = env.step(action)
 
@@ -398,8 +438,11 @@ def _run_batch(
       segment = torch.linalg.vector_norm(xy - prev_xy, dim=1)
       prev_xy = xy.clone()
 
-      left = base_env.scene["left_wheel_contact"].data.found.flatten(start_dim=1).any(dim=1)
-      right = base_env.scene["right_wheel_contact"].data.found.flatten(start_dim=1).any(dim=1)
+      left_data = base_env.scene["left_wheel_contact"].data.found
+      right_data = base_env.scene["right_wheel_contact"].data.found
+      assert left_data is not None and right_data is not None
+      left = left_data.flatten(start_dim=1).any(dim=1)
+      right = right_data.flatten(start_dim=1).any(dim=1)
       both_supported = left & right
       airborne = ~left & ~right
 
@@ -439,19 +482,15 @@ def _run_batch(
         sum_velocity_tracking_sq += (
           torch.mean(torch.square(actual_twist - twist_target), dim=1) * weight
         )
+      if height_target is not None:
+        sum_height_tracking_sq += torch.square(height - height_target[:, 0]) * weight
       episode_steps += active.long()
 
       if is_recovery_task:
-        from ascento_mjlab.mdp.recovery import RecoveryEnvelope
+        from ascento_mjlab.mdp.recovery import RecoveryEnvelope, recovery_condition
 
         envelope = RecoveryEnvelope()
-        recovery_stable = (
-          (height >= envelope.min_height)
-          & (tilt <= envelope.max_tilt_radians)
-          & (linear_speed <= envelope.max_linear_speed)
-          & (angular_speed <= envelope.max_angular_speed)
-          & both_supported
-        )
+        recovery_stable = recovery_condition(base_env, envelope)
         recovery_stable_count = torch.where(
           active & recovery_stable,
           recovery_stable_count + 1,
@@ -466,7 +505,6 @@ def _run_batch(
           recovery_from_start_s[newly_recovered_from_start] = first_stable_step * step_dt
           recovery_success |= newly_recovered_from_start
 
-      # Recovery begins only after the last configured disturbance has ended.
       after_disturbance = active & (disturbance_end >= 0) & (step >= disturbance_end)
       stable_now = (
         (tilt <= 0.08)
@@ -480,10 +518,8 @@ def _run_batch(
         stable_count + 1,
         torch.where(after_disturbance, torch.zeros_like(stable_count), stable_count),
       )
-      newly_recovered = (
-        after_disturbance
-        & ~recovered
-        & (stable_count >= stable_steps_required)
+      newly_recovered = after_disturbance & ~recovered & (
+        stable_count >= stable_steps_required
       )
       if bool(newly_recovered.any().item()):
         first_stable_step = step - stable_steps_required + 1
@@ -505,8 +541,7 @@ def _run_batch(
 
       if bool(finish.any().item()):
         final_xy_snapshot[finish] = xy[finish]
-        failed_ids = failed.nonzero(as_tuple=False).squeeze(-1
-        )
+        failed_ids = failed.nonzero(as_tuple=False).squeeze(-1)
         if len(failed_ids) > 0:
           for env_id, reason in _termination_reasons(base_env, failed_ids).items():
             termination_reason[env_id] = reason
@@ -522,9 +557,8 @@ def _run_batch(
             termination_reason[env_id] = timeout_names[0] if timeout_names else "horizon"
         finished_success |= succeeded
         active &= ~finish
-        policy.reset(finish.nonzero(as_tuple=False).squeeze(-1))
+        _reset_finished_slots(base_env, policy, finish)
 
-    # Any still-active environment is an evaluator failure, not a policy fail.
     if bool(active.any().item()):
       raise RuntimeError("Evaluation loop ended with unfinished scenarios")
 
@@ -557,6 +591,7 @@ def _run_batch(
     }
     if is_velocity_task:
       arrays["velocity_tracking_rmse"] = torch.sqrt(sum_velocity_tracking_sq / denom)
+      arrays["height_tracking_rmse"] = torch.sqrt(sum_height_tracking_sq / denom)
     if is_recovery_task:
       arrays["recovery_success"] = recovery_success.float()
       arrays["recovery_from_start_s"] = recovery_from_start_s
@@ -623,9 +658,6 @@ def run_scenarios(
 
   results: list[EpisodeResult] = []
   batch_metadata: list[dict[str, Any]] = []
-  # Keep batches family-homogeneous. Besides making statistical provenance
-  # clearer, this prevents short-horizon finished slots from being simulated
-  # for tens of seconds while a longer family in the same vector batch runs.
   family_order = list(dict.fromkeys(scenario.family for scenario in scenarios))
   for family in family_order:
     family_scenarios = [scenario for scenario in scenarios if scenario.family == family]

--- a/src/ascento_mjlab/mdp/commands.py
+++ b/src/ascento_mjlab/mdp/commands.py
@@ -1,4 +1,4 @@
-"""Ascento velocity and one-shot motion commands."""
+"""Ascento velocity, height, and one-shot motion commands."""
 
 from __future__ import annotations
 
@@ -7,6 +7,44 @@ from dataclasses import dataclass
 import torch
 from mjlab.managers.command_manager import CommandTerm, CommandTermCfg
 from mjlab.tasks.velocity.mdp import UniformVelocityCommandCfg
+
+
+@dataclass(kw_only=True)
+class AscentoHeightCommandCfg(CommandTermCfg):
+  """Uniform scalar body-height command."""
+
+  entity_name: str
+  height_range: tuple[float, float] = (0.70, 0.80)
+
+  def __post_init__(self) -> None:
+    if self.height_range[0] > self.height_range[1]:
+      raise ValueError("height_range must be ordered low <= high")
+
+  def build(self, env) -> AscentoHeightCommand:
+    return AscentoHeightCommand(self, env)
+
+
+class AscentoHeightCommand(CommandTerm):
+  """One-channel target body height in metres."""
+
+  def __init__(self, cfg: AscentoHeightCommandCfg, env) -> None:
+    super().__init__(cfg, env)
+    self._command = torch.zeros((self.num_envs, 1), device=self.device)
+
+  @property
+  def command(self) -> torch.Tensor:
+    return self._command
+
+  def _update_metrics(self) -> None:
+    return
+
+  def _resample_command(self, env_ids: torch.Tensor) -> None:
+    low, high = self.cfg.height_range
+    samples = torch.rand(len(env_ids), device=self.device)
+    self._command[env_ids, 0] = samples.mul(high - low).add(low)
+
+  def _update_command(self, env_ids: torch.Tensor | None) -> None:
+    del env_ids
 
 
 @dataclass(kw_only=True)
@@ -59,15 +97,18 @@ class AscentoMotionCommand(CommandTerm):
 
   def _update_command(self, env_ids: torch.Tensor | None) -> None:
     if env_ids is None:
-      # Keep a pulse sampled during this compute visible for the next policy
-      # observation, then clear it on the following step.
       consumed = ~self._pulse_is_new
       self._command[consumed, 3] = 0.0
       self._pulse_is_new[:] = False
     else:
-      # Reset keeps the freshly sampled pulse visible to the first policy action.
       self._command[env_ids, 3] = self._jump_pulse[env_ids].float()
       self._pulse_is_new[env_ids] = False
 
 
-__all__ = ["AscentoMotionCommandCfg", "UniformVelocityCommandCfg"]
+__all__ = [
+  "AscentoHeightCommand",
+  "AscentoHeightCommandCfg",
+  "AscentoMotionCommand",
+  "AscentoMotionCommandCfg",
+  "UniformVelocityCommandCfg",
+]

--- a/src/ascento_mjlab/mdp/jump.py
+++ b/src/ascento_mjlab/mdp/jump.py
@@ -1,8 +1,8 @@
 """Flat-ground jump state semantics.
 
-The initial port keeps jump state derived from contact and root motion.  A
-persistent state owner will be added only if observations/rewards demonstrate
-that derived signals are insufficient; no parallel FSM is introduced here.
+Jump events are synchronized during reward computation from one contact sample
+instead of through a later step event.  This keeps reward events and the next
+observation on the same policy transition.
 """
 
 from dataclasses import dataclass
@@ -21,6 +21,8 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
       "landing": torch.zeros(env.num_envs, device=env.device),
       "air_time": torch.zeros(env.num_envs, device=env.device),
       "takeoff_height": torch.zeros(env.num_envs, device=env.device),
+      "last_airborne_vz": torch.zeros(env.num_envs, device=env.device),
+      "landing_preimpact_vz": torch.zeros(env.num_envs, device=env.device),
     }
   state = env.ascento_jump_state
   state["supported"][ids] = True
@@ -29,36 +31,74 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
   state["landing"][ids] = 0.0
   state["air_time"][ids] = 0.0
   state["takeoff_height"][ids] = 0.0
+  state["last_airborne_vz"][ids] = 0.0
+  state["landing_preimpact_vz"][ids] = 0.0
+
+
+def _wheel_contacts(env) -> tuple[torch.Tensor, torch.Tensor]:
+  left = env.scene["left_wheel_contact"].data.found
+  right = env.scene["right_wheel_contact"].data.found
+  assert left is not None and right is not None
+  return (
+    left.flatten(start_dim=1).any(dim=1),
+    right.flatten(start_dim=1).any(dim=1),
+  )
 
 
 def update_jump_state(
-  env, env_ids: torch.Tensor | None, dt: float | None = None
+  env, env_ids: torch.Tensor | None = None, dt: float | None = None
 ) -> None:
-  """Detect both-wheel takeoff and first subsequent contact."""
-  del env_ids
-  # This event runs once per environment step, so use the active environment
-  # timing (physics timestep multiplied by decimation). The optional argument
-  # keeps the state transition directly testable with a supplied duration.
+  """Synchronize takeoff/landing state from the current wheel-contact sample.
+
+  Takeoff requires both wheels to leave the ground. Landing is the first
+  subsequent contact by either wheel.  ``landing_preimpact_vz`` is sampled from
+  the final prior airborne policy sample, independently from any contact
+  hysteresis or later two-wheel support.
+  """
+  if not hasattr(env, "ascento_jump_state"):
+    initialize_jump_state(env)
   dt = env.step_dt if dt is None else dt
-  left = env.scene["left_wheel_contact"].data.found > 0
-  right = env.scene["right_wheel_contact"].data.found > 0
-  left = left.flatten(start_dim=1).any(dim=1)
-  right = right.flatten(start_dim=1).any(dim=1)
+  left, right = _wheel_contacts(env)
   supported = left & right
-  airborne = ~left & ~right
+  any_contact = left | right
+  airborne = ~any_contact
   state = env.ascento_jump_state
-  state["takeoff"].zero_()
-  state["landing"].zero_()
-  takeoff = state["supported"] & airborne
-  landing = state["airborne"] & supported
+
+  ids = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+  if env_ids is not None:
+    ids.zero_()
+    ids[env_ids] = True
+
+  previous_supported = state["supported"].clone()
+  previous_airborne = state["airborne"].clone()
+  takeoff = ids & previous_supported & airborne
+  landing = ids & previous_airborne & any_contact
+
+  state["takeoff"][ids] = 0.0
+  state["landing"][ids] = 0.0
   state["takeoff"][takeoff] = 1.0
   state["landing"][landing] = 1.0
-  state["air_time"] = torch.where(airborne, state["air_time"] + dt, state["air_time"])
+
+  state["air_time"][ids] = torch.where(
+    airborne[ids], state["air_time"][ids] + dt, state["air_time"][ids]
+  )
   state["air_time"][takeoff] = dt
-  root_height = env.scene["robot"].data.root_link_pos_w[:, 2]
+
+  robot = env.scene["robot"]
+  root_height = robot.data.root_link_pos_w[:, 2]
+  root_vz = robot.data.root_link_lin_vel_w[:, 2]
   state["takeoff_height"][takeoff] = root_height[takeoff]
-  state["supported"] = supported
-  state["airborne"] = airborne
+  state["landing_preimpact_vz"][landing] = state["last_airborne_vz"][landing]
+  state["last_airborne_vz"][ids & airborne] = root_vz[ids & airborne]
+
+  state["supported"][ids] = supported[ids]
+  state["airborne"][ids] = airborne[ids]
+
+
+def sync_jump_state_reward(env) -> torch.Tensor:
+  """Update jump state before jump-dependent rewards, contributing zero reward."""
+  update_jump_state(env)
+  return torch.zeros(env.num_envs, device=env.device)
 
 
 def phase_features(env) -> torch.Tensor:
@@ -67,7 +107,13 @@ def phase_features(env) -> torch.Tensor:
     initialize_jump_state(env)
   state = env.ascento_jump_state
   return torch.stack(
-    [state["airborne"].float(), state["takeoff"], state["landing"], state["air_time"].clamp(max=2.0)], dim=1
+    [
+      state["airborne"].float(),
+      state["takeoff"],
+      state["landing"],
+      state["air_time"].clamp(max=2.0),
+    ],
+    dim=1,
   )
 
 
@@ -81,8 +127,9 @@ def landing_bonus(env) -> torch.Tensor:
 
 @dataclass(frozen=True)
 class JumpSemantics:
-  """Definitions shared by future jump rewards and capture metrics."""
+  """Definitions shared by jump rewards, evaluation, and capture metrics."""
 
   takeoff_requires_both_wheels_airborne: bool = True
   landing_is_first_subsequent_wheel_contact: bool = True
+  landing_impact_uses_precontact_vertical_speed: bool = True
   terrain_enabled: bool = False

--- a/src/ascento_mjlab/mdp/recovery.py
+++ b/src/ascento_mjlab/mdp/recovery.py
@@ -1,4 +1,6 @@
-"""Recovery envelope definitions."""
+"""Recovery shaping and executable recovery-success semantics."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 
@@ -19,13 +21,68 @@ class RecoveryEnvelope:
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 
 
+def _sensor_contact(env, name: str) -> torch.Tensor:
+  found = env.scene[name].data.found
+  assert found is not None
+  return found.flatten(start_dim=1).any(dim=1)
+
+
+def recovery_condition(
+  env,
+  envelope: RecoveryEnvelope = RecoveryEnvelope(),
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  """Return whether each environment is presently inside the recovery envelope."""
+  asset: Entity = env.scene[asset_cfg.name]
+  gravity_xy = torch.linalg.vector_norm(asset.data.projected_gravity_b[:, :2], dim=1)
+  tilt = torch.atan2(
+    gravity_xy,
+    -asset.data.projected_gravity_b[:, 2].clamp(max=-1.0e-6),
+  )
+  linear_speed = torch.linalg.vector_norm(asset.data.root_link_lin_vel_b, dim=1)
+  angular_speed = torch.linalg.vector_norm(asset.data.root_link_ang_vel_b, dim=1)
+  supported = _sensor_contact(env, "left_wheel_contact") & _sensor_contact(
+    env, "right_wheel_contact"
+  )
+  return (
+    (asset.data.root_link_pos_w[:, 2] >= envelope.min_height)
+    & (tilt <= envelope.max_tilt_radians)
+    & (linear_speed <= envelope.max_linear_speed)
+    & (angular_speed <= envelope.max_angular_speed)
+    & supported
+  )
+
+
+class RecoverySuccess:
+  """Stateful metric requiring the envelope continuously for ``stable_duration_s``."""
+
+  def __init__(self, cfg, env) -> None:
+    self.envelope = cfg.params.get("envelope", RecoveryEnvelope())
+    self._stable_steps = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+    self._required_steps = max(1, round(self.envelope.stable_duration_s / env.step_dt))
+
+  def __call__(self, env, envelope: RecoveryEnvelope | None = None) -> torch.Tensor:
+    active_envelope = self.envelope if envelope is None else envelope
+    stable = recovery_condition(env, active_envelope)
+    self._stable_steps = torch.where(
+      stable, self._stable_steps + 1, torch.zeros_like(self._stable_steps)
+    )
+    return (self._stable_steps >= self._required_steps).float()
+
+  def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+    ids = slice(None) if env_ids is None else env_ids
+    self._stable_steps[ids] = 0
+
+
 def recovery_progress(
   env,
   asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
 ) -> torch.Tensor:
-  """Progress toward an upright, supported, low-velocity recovery envelope."""
+  """Smooth shaping toward an upright, low-velocity recovery state."""
   asset: Entity = env.scene[asset_cfg.name]
-  upright = torch.exp(-torch.sum(torch.square(asset.data.projected_gravity_b[:, :2]), dim=1) / 0.35**2)
+  upright = torch.exp(
+    -torch.sum(torch.square(asset.data.projected_gravity_b[:, :2]), dim=1) / 0.35**2
+  )
   height = torch.exp(-torch.square(asset.data.root_link_pos_w[:, 2] - 0.75) / 0.10**2)
   speed = torch.linalg.vector_norm(asset.data.root_link_lin_vel_b, dim=1)
   return upright * height * torch.exp(-torch.square(speed) / 2.0**2)

--- a/src/ascento_mjlab/mdp/rewards.py
+++ b/src/ascento_mjlab/mdp/rewards.py
@@ -39,6 +39,20 @@ def height_tracking(
   return torch.exp(-torch.square(error) / (std * std))
 
 
+def commanded_height_tracking(
+  env: ManagerBasedRlEnv,
+  command_name: str = "height",
+  std: float = 0.05,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  """Track a scalar body-height command without a competing fixed-height term."""
+  asset: Entity = env.scene[asset_cfg.name]
+  command = env.command_manager.get_command(command_name)
+  assert command is not None and command.shape[1] == 1
+  error = asset.data.root_link_pos_w[:, 2] - command[:, 0]
+  return torch.exp(-torch.square(error) / (std * std))
+
+
 def angular_rate_penalty(
   env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
 ) -> torch.Tensor:

--- a/src/ascento_mjlab/physics.py
+++ b/src/ascento_mjlab/physics.py
@@ -1,0 +1,28 @@
+"""Canonical simulation-only physics/timing contract for Ascento tasks.
+
+Keep project-wide values that must agree across the plant, action mapping,
+sensors, capture metadata, and tests here. Runtime code should still prefer the
+active environment/model timestep when a task intentionally overrides it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PhysicsProfile:
+  name: str = "animation_high_authority"
+  sim_dt_s: float = 0.002
+  decimation: int = 5
+  peak_effort_nm: float = 40.0
+  default_root_height_m: float = 0.75
+
+  @property
+  def control_dt_s(self) -> float:
+    return self.sim_dt_s * self.decimation
+
+
+PHYSICS_PROFILE = PhysicsProfile()
+
+__all__ = ["PHYSICS_PROFILE", "PhysicsProfile"]

--- a/src/ascento_mjlab/robot_cfg.py
+++ b/src/ascento_mjlab/robot_cfg.py
@@ -1,6 +1,6 @@
 """Ascento Guard-2 robot entity configuration.
 
-The MJCF is deliberately limited to the robot.  The floor, lighting, cameras,
+The MJCF is deliberately limited to the robot. The floor, lighting, cameras,
 and environment spacing belong to the mjlab scene configuration.
 """
 
@@ -13,11 +13,9 @@ from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.sim import MujocoCfg, SimulationCfg
 from mjlab.viewer import ViewerConfig
 
-from .actuator import (
-  LEG_ACTUATOR,
-  WHEEL_ACTUATOR,
-  AscentoTorqueActuatorCfg,
-)
+from .actuator import LEG_ACTUATOR, WHEEL_ACTUATOR
+from .actuator_impl import AscentoTorqueActuatorCfg
+from .physics import PHYSICS_PROFILE
 
 ROBOT_XML = Path(__file__).parent / "assets" / "ascento_guard2" / "robot.xml"
 JOINT_NAMES = (
@@ -31,9 +29,9 @@ JOINT_NAMES = (
 LEG_JOINT_NAMES = ("left_hip", "left_knee", "right_hip", "right_knee")
 WHEEL_JOINT_NAMES = ("left_wheel_joint", "right_wheel_joint")
 
-# The source model is a two-link serial leg with 0.25 m wheels.  -pi is the
-# straight-down nominal pose and 0.75 m leaves the wheels supported without
-# penetrating the plane.
+# The source model is a two-link serial leg with 0.25 m wheels. -pi is the
+# straight-down nominal pose and the canonical root height leaves the wheels
+# supported without penetrating the plane.
 DEFAULT_POSE = {
   "left_hip": -3.141592653589793,
   "left_knee": -3.141592653589793,
@@ -42,7 +40,8 @@ DEFAULT_POSE = {
   "right_knee": -3.141592653589793,
   "right_wheel_joint": 0.0,
 }
-DEFAULT_ROOT_HEIGHT = 0.75
+DEFAULT_ROOT_HEIGHT = PHYSICS_PROFILE.default_root_height_m
+
 
 def get_spec() -> mujoco.MjSpec:
   """Load a fresh robot spec for each entity variant."""
@@ -89,7 +88,7 @@ VIEWER_CONFIG = ViewerConfig(
 
 SIM_CFG = SimulationCfg(
   mujoco=MujocoCfg(
-    timestep=0.002,
+    timestep=PHYSICS_PROFILE.sim_dt_s,
     iterations=10,
     ls_iterations=20,
   ),

--- a/src/ascento_mjlab/tasks/balance/env_cfg.py
+++ b/src/ascento_mjlab/tasks/balance/env_cfg.py
@@ -18,6 +18,7 @@ from mjlab.sensor import ContactMatch, ContactSensorCfg
 from mjlab.terrains import TerrainEntityCfg
 
 from ascento_mjlab import mdp as ascento_mdp
+from ascento_mjlab.physics import PHYSICS_PROFILE
 from ascento_mjlab.robot_cfg import (
   DEFAULT_ASCENTO_CFG,
   JOINT_NAMES,
@@ -47,7 +48,7 @@ def _scene(num_envs: int) -> SceneCfg:
         fields=("found", "force"),
         reduce="netforce",
         track_air_time=True,
-        history_length=5,
+        history_length=PHYSICS_PROFILE.decimation,
       ),
       ContactSensorCfg(
         name="right_wheel_contact",
@@ -56,83 +57,99 @@ def _scene(num_envs: int) -> SceneCfg:
         fields=("found", "force"),
         reduce="netforce",
         track_air_time=True,
-        history_length=5,
+        history_length=PHYSICS_PROFILE.decimation,
       ),
     ),
   )
 
 
 def _observations(play: bool) -> dict[str, ObservationGroupCfg]:
+  effort_limit = PHYSICS_PROFILE.peak_effort_nm
   actor_terms = {
     "gravity": ObservationTermCfg(func=mdp.projected_gravity, params={"asset_cfg": ROBOT_CFG}),
     "base_lin_vel": ObservationTermCfg(func=mdp.base_lin_vel, params={"asset_cfg": ROBOT_CFG}),
     "base_ang_vel": ObservationTermCfg(func=mdp.base_ang_vel, params={"asset_cfg": ROBOT_CFG}),
     "height": ObservationTermCfg(
-      func=ascento_mdp.observations.base_height, params={"asset_cfg": ROBOT_CFG}, scale=1.0
+      func=ascento_mdp.observations.base_height,
+      params={"asset_cfg": ROBOT_CFG},
+      scale=1.0,
     ),
     "joint_pos": ObservationTermCfg(func=mdp.joint_pos_rel, params={"asset_cfg": ROBOT_CFG}),
     "joint_vel": ObservationTermCfg(func=mdp.joint_vel_rel, params={"asset_cfg": ROBOT_CFG}),
     "contacts": ObservationTermCfg(
       func=ascento_mdp.observations.wheel_contacts,
-      params={"left_sensor_name": "left_wheel_contact", "right_sensor_name": "right_wheel_contact"},
+      params={
+        "left_sensor_name": "left_wheel_contact",
+        "right_sensor_name": "right_wheel_contact",
+      },
     ),
     "contact_forces": ObservationTermCfg(
       func=ascento_mdp.observations.wheel_contact_forces,
-      params={"left_sensor_name": "left_wheel_contact", "right_sensor_name": "right_wheel_contact"},
+      params={
+        "left_sensor_name": "left_wheel_contact",
+        "right_sensor_name": "right_wheel_contact",
+      },
       clip=(0.0, 2000.0),
       scale=0.01,
     ),
     "effort": ObservationTermCfg(
       func=ascento_mdp.observations.actuator_effort,
       params={"asset_cfg": ROBOT_CFG},
-      clip=(-40.0, 40.0),
-      scale=0.025,
+      clip=(-effort_limit, effort_limit),
+      scale=1.0 / effort_limit,
     ),
     "actions": ObservationTermCfg(func=mdp.last_action),
   }
   critic_terms = {
     **actor_terms,
     "root_pos": ObservationTermCfg(func=lambda env: env.scene["robot"].data.root_link_pos_w),
-    "root_lin_vel_w": ObservationTermCfg(func=lambda env: env.scene["robot"].data.root_link_lin_vel_w),
-    "root_ang_vel_w": ObservationTermCfg(func=lambda env: env.scene["robot"].data.root_link_ang_vel_w),
+    "root_lin_vel_w": ObservationTermCfg(
+      func=lambda env: env.scene["robot"].data.root_link_lin_vel_w
+    ),
+    "root_ang_vel_w": ObservationTermCfg(
+      func=lambda env: env.scene["robot"].data.root_link_ang_vel_w
+    ),
   }
   return {
-    "actor": ObservationGroupCfg(terms=actor_terms, concatenate_terms=True, enable_corruption=False),
-    "critic": ObservationGroupCfg(terms=critic_terms, concatenate_terms=True, enable_corruption=False),
+    "actor": ObservationGroupCfg(
+      terms=actor_terms, concatenate_terms=True, enable_corruption=False
+    ),
+    "critic": ObservationGroupCfg(
+      terms=critic_terms, concatenate_terms=True, enable_corruption=False
+    ),
   }
 
 
 def _actions() -> dict[str, ActionTermCfg]:
+  effort_limit = PHYSICS_PROFILE.peak_effort_nm
   return {
     "effort": JointEffortActionCfg(
       entity_name="robot",
       actuator_names=JOINT_NAMES,
-      scale=40.0,
-      # JointEffortActionCfg clips *after* scale/offset.  The physical target
-      # therefore needs a +/-40 Nm clamp; using +/-1 here silently reduces the
-      # robot to +/-1 Nm despite the 40 Nm action scale.
-      clip={".*": (-40.0, 40.0)},
+      scale=effort_limit,
+      # JointEffortActionCfg clips after scale/offset. The physical target
+      # therefore needs the physical Nm clamp, not the normalized policy clamp.
+      clip={".*": (-effort_limit, effort_limit)},
       preserve_order=True,
     )
   }
 
 
-def ascento_balance_env_cfg(play: bool = False, num_envs: int = 512) -> ManagerBasedRlEnvCfg:
-  """Build the validated flat-ground balance configuration.
-
-  ``num_envs`` defaults to a conservative RTX 3060 starting point.  The
-  environment itself has no terrain generator; terrain is intentionally kept
-  behind the successful flat-ground jump gate.
-  """
+def ascento_balance_env_cfg(
+  play: bool = False, num_envs: int = 512
+) -> ManagerBasedRlEnvCfg:
+  """Build the validated flat-ground balance configuration."""
   cfg = ManagerBasedRlEnvCfg(
-    decimation=5,
+    decimation=PHYSICS_PROFILE.decimation,
     scene=_scene(1 if play else num_envs),
     sim=deepcopy(SIM_CFG),
     viewer=deepcopy(VIEWER_CONFIG),
     observations=_observations(play),
     actions=_actions(),
     events={
-      "reset_scene_to_default": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset"),
+      "reset_scene_to_default": EventTermCfg(
+        func=mdp.reset_scene_to_default, mode="reset"
+      ),
       "reset_supported_pose": EventTermCfg(
         func=ascento_mdp.events.reset_root_state_uniform,
         mode="reset",
@@ -167,16 +184,17 @@ def ascento_balance_env_cfg(play: bool = False, num_envs: int = 512) -> ManagerB
       "height": RewardTermCfg(
         func=ascento_mdp.rewards.height_tracking,
         weight=1.0,
-        params={"target": 0.75, "std": 0.08, "asset_cfg": ROBOT_CFG},
+        params={
+          "target": PHYSICS_PROFILE.default_root_height_m,
+          "std": 0.08,
+          "asset_cfg": ROBOT_CFG,
+        },
       ),
       "angular_rate": RewardTermCfg(
         func=ascento_mdp.rewards.angular_rate_penalty,
         weight=-0.04,
         params={"asset_cfg": ROBOT_CFG},
       ),
-      # Balance should be stationary on average.  This is deliberately mild:
-      # wheel translation remains available for recovery, but persistent drift
-      # is no longer reward-equivalent to balancing in place.
       "planar_speed": RewardTermCfg(
         func=ascento_mdp.rewards.planar_speed_penalty,
         weight=-0.2,
@@ -187,14 +205,17 @@ def ascento_balance_env_cfg(play: bool = False, num_envs: int = 512) -> ManagerB
         weight=-0.0005,
         params={"asset_cfg": ROBOT_CFG},
       ),
-      "action_rate": RewardTermCfg(func=ascento_mdp.rewards.action_rate_penalty, weight=-0.02),
+      "action_rate": RewardTermCfg(
+        func=ascento_mdp.rewards.action_rate_penalty, weight=-0.02
+      ),
     },
     terminations={
       "fallen": TerminationTermCfg(
         func=ascento_mdp.terminations.fallen, params={"asset_cfg": ROBOT_CFG}
       ),
       "excessive_velocity": TerminationTermCfg(
-        func=ascento_mdp.terminations.excessive_velocity, params={"asset_cfg": ROBOT_CFG}
+        func=ascento_mdp.terminations.excessive_velocity,
+        params={"asset_cfg": ROBOT_CFG},
       ),
       "nonfinite": TerminationTermCfg(
         func=ascento_mdp.terminations.nonfinite, params={"asset_cfg": ROBOT_CFG}

--- a/src/ascento_mjlab/tasks/jump/env_cfg.py
+++ b/src/ascento_mjlab/tasks/jump/env_cfg.py
@@ -1,6 +1,6 @@
 """Flat-ground jump specialist configuration placeholder.
 
-Terrain is intentionally disabled here.  This task is not expanded until
+Terrain is intentionally disabled here. This task is not expanded until
 takeoff, flight, landing, and post-landing recovery are sound on a plane.
 """
 
@@ -34,15 +34,23 @@ def ascento_jump_env_cfg(play: bool = False, num_envs: int = 512):
   cfg.observations["actor"].terms["jump_state"] = ObservationTermCfg(
     func=ascento_mdp.observations.jump_state,
   )
-  cfg.observations["critic"].terms["motion_command"] = cfg.observations["actor"].terms["motion_command"]
-  cfg.observations["critic"].terms["jump_state"] = cfg.observations["actor"].terms["jump_state"]
+  cfg.observations["critic"].terms["motion_command"] = cfg.observations["actor"].terms[
+    "motion_command"
+  ]
+  cfg.observations["critic"].terms["jump_state"] = cfg.observations["actor"].terms[
+    "jump_state"
+  ]
   cfg.events["initialize_jump_state"] = EventTermCfg(
     func=ascento_mdp.jump.initialize_jump_state,
     mode="reset",
   )
-  cfg.events["update_jump_state"] = EventTermCfg(
-    func=ascento_mdp.jump.update_jump_state,
-    mode="step",
+
+  # Reward computation happens before mjlab's step events. Synchronize the
+  # contact-derived jump state here so takeoff/landing rewards correspond to
+  # the same transition that produced the returned contact observation.
+  cfg.rewards["jump_state_sync"] = RewardTermCfg(
+    func=ascento_mdp.jump.sync_jump_state_reward,
+    weight=1.0,
   )
   cfg.rewards["takeoff"] = RewardTermCfg(func=ascento_mdp.rewards.jump_takeoff, weight=2.0)
   cfg.rewards["landing"] = RewardTermCfg(func=ascento_mdp.rewards.jump_landing, weight=3.0)

--- a/src/ascento_mjlab/tasks/recovery/env_cfg.py
+++ b/src/ascento_mjlab/tasks/recovery/env_cfg.py
@@ -1,5 +1,7 @@
 """Recovery specialist configuration."""
 
+from mjlab.envs import mdp
+from mjlab.managers.event_manager import EventTermCfg
 from mjlab.managers.metrics_manager import MetricsTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
 
@@ -21,6 +23,30 @@ def ascento_recovery_env_cfg(play: bool = False, num_envs: int = 512):
       "yaw": (-0.5, 0.5),
     }
   )
+
+  # Recovery should not only work when the disturbance happened at reset.
+  # mjlab's standard velocity-kick event is deterministic under the env seed,
+  # acts directly on the physical root state, and avoids adding sim-to-real
+  # noise that is irrelevant to this simulation-only project. Keep it out of
+  # play/evaluation configs, where disturbances are specified explicitly by
+  # the quantitative scenario suite instead.
+  if not play:
+    cfg.events["recovery_push"] = EventTermCfg(
+      func=mdp.push_by_setting_velocity,
+      mode="interval",
+      interval_range_s=(1.5, 3.5),
+      params={
+        "velocity_range": {
+          "x": (-0.35, 0.35),
+          "y": (-0.15, 0.15),
+          "z": (0.0, 0.0),
+          "roll": (-0.25, 0.25),
+          "pitch": (-0.35, 0.35),
+          "yaw": (-0.20, 0.20),
+        }
+      },
+    )
+
   cfg.rewards["recovery_progress"] = RewardTermCfg(
     func=ascento_mdp.recovery.recovery_progress,
     weight=2.0,

--- a/src/ascento_mjlab/tasks/recovery/env_cfg.py
+++ b/src/ascento_mjlab/tasks/recovery/env_cfg.py
@@ -1,5 +1,6 @@
 """Recovery specialist configuration."""
 
+from mjlab.managers.metrics_manager import MetricsTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
 
 from ascento_mjlab import mdp as ascento_mdp
@@ -12,11 +13,20 @@ def ascento_recovery_env_cfg(play: bool = False, num_envs: int = 512):
     {"roll": (-0.35, 0.35), "pitch": (-0.45, 0.45)}
   )
   cfg.events["reset_supported_pose"].params["velocity_range"].update(
-    {"x": (-0.8, 0.8), "y": (-0.4, 0.4), "roll": (-1.5, 1.5), "pitch": (-2.0, 2.0), "yaw": (-0.5, 0.5)}
+    {
+      "x": (-0.8, 0.8),
+      "y": (-0.4, 0.4),
+      "roll": (-1.5, 1.5),
+      "pitch": (-2.0, 2.0),
+      "yaw": (-0.5, 0.5),
+    }
   )
   cfg.rewards["recovery_progress"] = RewardTermCfg(
     func=ascento_mdp.recovery.recovery_progress,
     weight=2.0,
+  )
+  cfg.metrics["recovery_success"] = MetricsTermCfg(
+    func=ascento_mdp.recovery.RecoverySuccess,
   )
   cfg.episode_length_s = 5.0 if not play else 10000.0
   return cfg

--- a/src/ascento_mjlab/tasks/velocity/env_cfg.py
+++ b/src/ascento_mjlab/tasks/velocity/env_cfg.py
@@ -1,4 +1,4 @@
-"""Flat-ground velocity task built from the balance plant."""
+"""Flat-ground velocity/yaw/height task built from the balance plant."""
 
 from __future__ import annotations
 
@@ -23,15 +23,36 @@ def ascento_velocity_env_cfg(play: bool = False, num_envs: int = 512):
       ranges=UniformVelocityCommandCfg.Ranges(
         lin_vel_x=(-0.5, 0.5), lin_vel_y=(0.0, 0.0), ang_vel_z=(-0.6, 0.6)
       ),
-    )
+    ),
+    "height": ascento_mdp.commands.AscentoHeightCommandCfg(
+      entity_name="robot",
+      resampling_time_range=(3.0, 6.0),
+      height_range=(0.68, 0.82),
+      debug_vis=False,
+    ),
   }
   command_obs = ascento_mdp.observations.motion_command
-  term = ObservationTermCfg(func=command_obs, params={"command_name": "twist"})
-  cfg.observations["actor"].terms["command"] = term
-  cfg.observations["critic"].terms["command"] = term
+  twist_term = ObservationTermCfg(func=command_obs, params={"command_name": "twist"})
+  height_term = ObservationTermCfg(func=command_obs, params={"command_name": "height"})
+  cfg.observations["actor"].terms["twist_command"] = twist_term
+  cfg.observations["actor"].terms["height_command"] = height_term
+  cfg.observations["critic"].terms["twist_command"] = twist_term
+  cfg.observations["critic"].terms["height_command"] = height_term
+
+  # The balance objective rewards a fixed 0.75 m height and penalizes planar
+  # speed. Both conflict directly with this stage, where translation and body
+  # height are commanded. Keep the stabilizing terms but remove those two
+  # contradictory objectives before adding command tracking.
+  cfg.rewards.pop("height", None)
+  cfg.rewards.pop("planar_speed", None)
   cfg.rewards["track_velocity"] = RewardTermCfg(
     func=ascento_mdp.rewards.track_velocity,
     weight=2.0,
     params={"command_name": "twist", "std": 0.5},
+  )
+  cfg.rewards["track_height"] = RewardTermCfg(
+    func=ascento_mdp.rewards.commanded_height_tracking,
+    weight=1.0,
+    params={"command_name": "height", "std": 0.05},
   )
   return cfg

--- a/src/ascento_mjlab/tools/capture_motion.py
+++ b/src/ascento_mjlab/tools/capture_motion.py
@@ -17,10 +17,11 @@ from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.utils.wrappers import VideoRecorder
 
 import ascento_mjlab.tasks  # noqa: F401
+from ascento_mjlab.physics import PHYSICS_PROFILE
 
 
 def _jump_state_array(state: dict[str, torch.Tensor]) -> np.ndarray:
-  """Copy the four jump-state scalars to host memory as one float32 vector."""
+  """Copy the four public jump-state scalars to host memory as float32."""
   values = torch.stack(
     [
       state["airborne"][0],
@@ -36,8 +37,6 @@ def _configure_capture_cfg(cfg: Any, *, take: int) -> Any:
   """Configure a task for one continuous, non-auto-reset capture take."""
   cfg.scene.num_envs = 1
   cfg.seed = take
-  # A capture is one continuous trajectory. Auto-reset would make record_post_step()
-  # observe the reset pose after a terminal step and splice it into the same take.
   cfg.auto_reset = False
   cfg.recorders = {"motion": RecorderTermCfg(func=MotionRecorder, params={})}
   return cfg
@@ -89,6 +88,14 @@ class MotionRecorder(RecorderTerm):
       frame["contacts"] = np.asarray(contacts, dtype=np.float32)
     if hasattr(env, "ascento_jump_state"):
       frame["jump_state"] = _jump_state_array(env.ascento_jump_state)
+      if "landing_preimpact_vz" in env.ascento_jump_state:
+        frame["landing_preimpact_vz"] = (
+          env.ascento_jump_state["landing_preimpact_vz"][0]
+          .detach()
+          .cpu()
+          .numpy()
+          .copy()
+        )
     for command_name in ("motion", "twist"):
       try:
         command = env.command_manager.get_command(command_name)
@@ -97,6 +104,12 @@ class MotionRecorder(RecorderTerm):
       if command is not None:
         frame["command"] = command[0].detach().cpu().numpy().copy()
         break
+    try:
+      height_command = env.command_manager.get_command("height")
+    except (AttributeError, KeyError):
+      height_command = None
+    if height_command is not None:
+      frame["height_command"] = height_command[0].detach().cpu().numpy().copy()
     self.frames.append(frame)
 
   def export(self, path: Path, *, metadata: dict[str, str]) -> None:
@@ -112,12 +125,18 @@ class MotionRecorder(RecorderTerm):
 def main() -> None:
   parser = argparse.ArgumentParser(description=__doc__)
   parser.add_argument("--task", default="Ascento-Balance-Flat")
-  parser.add_argument("--checkpoint", type=Path, default=None, help="RSL-RL checkpoint to play")
+  parser.add_argument(
+    "--checkpoint", type=Path, default=None, help="RSL-RL checkpoint to play"
+  )
   parser.add_argument("--takes", type=int, default=1)
   parser.add_argument("--steps", type=int, default=1000)
   parser.add_argument("--output-dir", type=Path, default=Path("captures"))
-  parser.add_argument("--video-dir", type=Path, default=None, help="Optional MP4 output directory")
-  parser.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+  parser.add_argument(
+    "--video-dir", type=Path, default=None, help="Optional MP4 output directory"
+  )
+  parser.add_argument(
+    "--device", default="cuda:0" if torch.cuda.is_available() else "cpu"
+  )
   args = parser.parse_args()
   if args.takes < 1 or args.steps < 1:
     parser.error("--takes and --steps must be positive")
@@ -173,9 +192,11 @@ def main() -> None:
         "task": args.task,
         "seed": str(take),
         "fps": str(round(1.0 / base_env.step_dt)),
+        "physics_timestep_s": str(float(base_env.cfg.sim.mujoco.timestep)),
+        "policy_timestep_s": str(float(base_env.step_dt)),
         "checkpoint": str(args.checkpoint) if args.checkpoint is not None else "",
         "model_sha256": checkpoint_hash,
-        "physics_profile": "animation_high_authority",
+        "physics_profile": PHYSICS_PROFILE.name,
         "captured_steps": str(captured_steps),
         "ended_on_done": str(ended_on_done).lower(),
       },

--- a/tests_mjlab/evaluation/test_runner_lifecycle.py
+++ b/tests_mjlab/evaluation/test_runner_lifecycle.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import torch
+
+from ascento_mjlab.evaluation.runner import (
+  _refresh_exact_observation_history,
+  _reset_finished_slots,
+)
+
+
+class _ObservationManager:
+  def __init__(self):
+    self.reset_ids = None
+    self.compute_ids = None
+
+  def reset(self, env_ids):
+    self.reset_ids = env_ids.clone()
+
+  def compute(self, *, update_history, env_ids):
+    assert update_history is True
+    self.compute_ids = env_ids.clone()
+    return {"actor": torch.arange(len(env_ids), dtype=torch.float32)[:, None]}
+
+
+def test_exact_reset_reseeds_observation_history_from_resolved_state():
+  manager = _ObservationManager()
+  env = SimpleNamespace(
+    num_envs=3,
+    device="cpu",
+    observation_manager=manager,
+    obs_buf=None,
+  )
+
+  _refresh_exact_observation_history(env)
+
+  expected = torch.tensor([0, 1, 2])
+  assert torch.equal(manager.reset_ids, expected)
+  assert torch.equal(manager.compute_ids, expected)
+  assert torch.equal(env.obs_buf["actor"].flatten(), torch.tensor([0.0, 1.0, 2.0]))
+
+
+def test_finished_vector_slots_are_reset_before_next_step():
+  reset_calls = []
+  policy_calls = []
+  env = SimpleNamespace(reset=lambda *, env_ids: reset_calls.append(env_ids.clone()))
+  policy = SimpleNamespace(reset=lambda env_ids: policy_calls.append(env_ids.clone()))
+  finish = torch.tensor([False, True, False, True])
+
+  _reset_finished_slots(env, policy, finish)
+
+  expected = torch.tensor([1, 3])
+  assert len(reset_calls) == len(policy_calls) == 1
+  assert torch.equal(reset_calls[0], expected)
+  assert torch.equal(policy_calls[0], expected)
+
+
+def test_no_finished_slots_do_not_trigger_reset():
+  env = SimpleNamespace(reset=lambda **kwargs: (_ for _ in ()).throw(AssertionError(kwargs)))
+  policy = SimpleNamespace(reset=lambda *args: (_ for _ in ()).throw(AssertionError(args)))
+
+  _reset_finished_slots(env, policy, torch.zeros(4, dtype=torch.bool))

--- a/tests_mjlab/test_import_order.py
+++ b/tests_mjlab/test_import_order.py
@@ -24,6 +24,12 @@ from mjlab.tasks.registry import list_tasks
 assert 'Ascento-Jump-Flat' in list_tasks()
 assert ascento_jump_env_cfg(num_envs=1).scene.num_envs == 1
 """,
+    """
+import ascento_mjlab.actuator
+from mjlab.tasks.registry import load_env_cfg, list_tasks
+assert 'Ascento-Balance-Flat' in list_tasks()
+assert load_env_cfg('Ascento-Balance-Flat').scene.num_envs == 512
+""",
   ],
 )
 def test_task_registration_is_independent_of_import_order(source):

--- a/tests_mjlab/test_jump_semantics.py
+++ b/tests_mjlab/test_jump_semantics.py
@@ -4,13 +4,39 @@ import pytest
 import torch
 
 from ascento_mjlab.mdp.commands import AscentoMotionCommandCfg
-from ascento_mjlab.mdp.jump import JumpSemantics, update_jump_state
+from ascento_mjlab.mdp.jump import (
+  JumpSemantics,
+  initialize_jump_state,
+  update_jump_state,
+)
+
+
+def _jump_env(*, step_dt: float = 0.01):
+  left = torch.ones((1, 1), dtype=torch.bool)
+  right = torch.ones((1, 1), dtype=torch.bool)
+  robot_data = SimpleNamespace(
+    root_link_pos_w=torch.tensor([[0.0, 0.0, 0.75]]),
+    root_link_lin_vel_w=torch.zeros((1, 3)),
+  )
+  env = SimpleNamespace(
+    num_envs=1,
+    device="cpu",
+    step_dt=step_dt,
+    scene={
+      "left_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=left)),
+      "right_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=right)),
+      "robot": SimpleNamespace(data=robot_data),
+    },
+  )
+  initialize_jump_state(env)
+  return env, left, right, robot_data
 
 
 def test_jump_semantics_keeps_terrain_behind_flat_ground_gate():
   semantics = JumpSemantics()
   assert semantics.takeoff_requires_both_wheels_airborne
   assert semantics.landing_is_first_subsequent_wheel_contact
+  assert semantics.landing_impact_uses_precontact_vertical_speed
   assert semantics.terrain_enabled is False
 
 
@@ -33,27 +59,44 @@ def test_motion_command_one_shot_is_explicitly_documented():
 
 
 def test_jump_state_defaults_to_active_environment_step_dt():
-  found = torch.zeros((1, 1), dtype=torch.bool)
-  state = {
-    "supported": torch.ones(1, dtype=torch.bool),
-    "airborne": torch.zeros(1, dtype=torch.bool),
-    "takeoff": torch.zeros(1),
-    "landing": torch.zeros(1),
-    "air_time": torch.zeros(1),
-    "takeoff_height": torch.zeros(1),
-  }
-  env = SimpleNamespace(
-    step_dt=0.037,
-    ascento_jump_state=state,
-    scene={
-      "left_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=found)),
-      "right_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=found)),
-      "robot": SimpleNamespace(
-        data=SimpleNamespace(root_link_pos_w=torch.tensor([[0.0, 0.0, 0.75]]))
-      ),
-    },
-  )
+  env, left, right, _ = _jump_env(step_dt=0.037)
+  left.zero_()
+  right.zero_()
 
-  update_jump_state(env, None)
+  update_jump_state(env)
 
-  assert state["air_time"].item() == pytest.approx(0.037)
+  assert env.ascento_jump_state["air_time"].item() == pytest.approx(0.037)
+  assert env.ascento_jump_state["takeoff"].item() == pytest.approx(1.0)
+
+
+def test_landing_is_first_subsequent_contact_even_with_one_wheel():
+  env, left, right, _ = _jump_env()
+  left.zero_()
+  right.zero_()
+  update_jump_state(env)
+  assert env.ascento_jump_state["airborne"].item()
+
+  left.fill_(True)
+  update_jump_state(env)
+
+  assert env.ascento_jump_state["landing"].item() == pytest.approx(1.0)
+  assert not env.ascento_jump_state["supported"].item()
+
+
+def test_landing_impact_uses_last_airborne_velocity_not_post_contact_velocity():
+  env, left, right, robot = _jump_env()
+  left.zero_()
+  right.zero_()
+  robot.root_link_lin_vel_w[0, 2] = 1.2
+  update_jump_state(env)
+
+  robot.root_link_lin_vel_w[0, 2] = -3.4
+  update_jump_state(env)
+  assert env.ascento_jump_state["last_airborne_vz"].item() == pytest.approx(-3.4)
+
+  left.fill_(True)
+  robot.root_link_lin_vel_w[0, 2] = -0.2
+  update_jump_state(env)
+
+  assert env.ascento_jump_state["landing"].item() == pytest.approx(1.0)
+  assert env.ascento_jump_state["landing_preimpact_vz"].item() == pytest.approx(-3.4)

--- a/tests_mjlab/test_task_config.py
+++ b/tests_mjlab/test_task_config.py
@@ -16,7 +16,9 @@ def test_balance_env_is_six_effort_flat_ground():
   obs, _ = env.reset()
   assert obs["actor"].shape[-1] == 38
   assert obs["critic"].shape[-1] == 47
-  obs, reward, terminated, truncated, _ = env.step(torch.zeros((cfg.scene.num_envs, 6)))
+  obs, reward, terminated, truncated, _ = env.step(
+    torch.zeros((cfg.scene.num_envs, 6))
+  )
   assert torch.isfinite(obs["actor"]).all()
   assert torch.isfinite(reward).all()
   assert not terminated.any()
@@ -47,6 +49,23 @@ def test_balance_rl_config_enforces_normalized_actions_and_instrumented_ppo():
   assert cfg.algorithm.class_name == "ascento_mjlab.ppo:InstrumentedPPO"
 
 
+def test_velocity_stage_has_no_reward_that_penalizes_its_commands():
+  cfg = load_env_cfg("Ascento-Velocity-Flat")
+
+  assert set(cfg.commands) == {"twist", "height"}
+  assert "height" not in cfg.rewards
+  assert "planar_speed" not in cfg.rewards
+  assert "track_velocity" in cfg.rewards
+  assert "track_height" in cfg.rewards
+  assert "twist_command" in cfg.observations["actor"].terms
+  assert "height_command" in cfg.observations["actor"].terms
+
+
+def test_recovery_stage_exports_executable_success_metric():
+  cfg = load_env_cfg("Ascento-Recovery-Flat")
+  assert "recovery_success" in cfg.metrics
+
+
 @pytest.mark.parametrize(
   "task_id",
   [
@@ -68,11 +87,13 @@ def test_all_flat_task_configs_construct_and_step(task_id):
   env.close()
 
 
-def test_jump_state_event_uses_environment_step_timing():
+def test_jump_state_is_synchronized_before_jump_dependent_rewards():
   cfg = load_env_cfg("Ascento-Jump-Flat")
-  event_cfg = cfg.events["update_jump_state"]
 
-  assert event_cfg.params == {}
+  assert "update_jump_state" not in cfg.events
+  reward_names = list(cfg.rewards)
+  assert reward_names.index("jump_state_sync") < reward_names.index("takeoff")
+  assert reward_names.index("jump_state_sync") < reward_names.index("landing")
   assert cfg.sim.mujoco.timestep * cfg.decimation == pytest.approx(0.01)
 
 

--- a/tests_mjlab/test_task_config.py
+++ b/tests_mjlab/test_task_config.py
@@ -61,9 +61,14 @@ def test_velocity_stage_has_no_reward_that_penalizes_its_commands():
   assert "height_command" in cfg.observations["actor"].terms
 
 
-def test_recovery_stage_exports_executable_success_metric():
+def test_recovery_stage_exports_executable_success_metric_and_training_pushes():
   cfg = load_env_cfg("Ascento-Recovery-Flat")
+  play_cfg = load_env_cfg("Ascento-Recovery-Flat", play=True)
+
   assert "recovery_success" in cfg.metrics
+  assert "recovery_push" in cfg.events
+  assert cfg.events["recovery_push"].mode == "interval"
+  assert "recovery_push" not in play_cfg.events
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Work-in-progress stabilization pass for #74. This branch targets correctness issues that can invalidate a longer training/evaluation run: import-order task registration, evaluator lifecycle, velocity objective consistency, recovery success, and jump event semantics. I will keep this PR draft until regression tests and CI are green.