### PR TITLE
Add run management, provenance, lineage, and comparison UI

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,19 +1,49 @@
 # Ascento Training Dashboard
 
-A local web dashboard for monitoring mjlab/RSL-RL training over Tailscale. It reads
-training artifacts and launcher metadata; it does not own the PPO algorithm itself.
+A local web control plane for mjlab/RSL-RL training over Tailscale. The dashboard
+monitors existing artifacts and can also start/stop managed training runs. PPO
+still belongs to mjlab/RSL-RL; the dashboard owns run lifecycle, provenance,
+console capture, health reporting, and comparison.
 
-## What it shows
+## Run management
 
-- current iteration, wall-clock freshness, environment-step throughput, elapsed time and ETA;
-- explicit iteration counts plus collected environment-transition totals when run config is available;
+The **Runs** page is now the default dashboard view. It supports:
+
+- starting a training run from the browser;
+- human-readable names independent of machine artifact directory names;
+- notes, tags, purpose, parent-run lineage and parent-checkpoint provenance;
+- editing metadata for old runs without moving or rewriting their artifacts;
+- graceful stop requests for dashboard-managed processes;
+- side-by-side comparison using normalized reward, episode-length, PPO-loss,
+  entropy, KL and clip-fraction telemetry;
+- explicit repository-version status for every run.
+
+Managed runs are launched through `python -m dashboard.launch`, so browser and
+CLI runs share the same metadata/status schema and console capture. The API
+starts each managed launcher in a dedicated process session. A stop request marks
+the run `stopping`, sends SIGINT to that process group, waits for trainer cleanup,
+and only escalates to terminate/kill if the process does not exit.
+
+Run metadata is stored next to the run as `run_metadata.json`. The artifact
+directory remains machine-oriented and immutable; display names and notes can be
+changed later without breaking paths.
+
+## What the monitor shows
+
+- current iteration, wall-clock freshness, environment-step throughput, elapsed
+  time and ETA;
+- explicit iteration counts plus collected environment-transition totals when
+  run config is available;
 - reward and episode-length trends;
-- PPO/surrogate loss, value loss, entropy, KL, clip fraction and invalid-update telemetry when reported by the trainer;
+- PPO/surrogate loss, value loss, entropy, KL, clip fraction and invalid-update
+  telemetry when reported by the trainer;
 - NaN/Inf detection across numeric telemetry;
 - stale-run detection when a run is still marked running but telemetry stops;
-- GPU utilization, memory and temperature, plus process-specific telemetry only when the dashboard shares the trainer's PID namespace;
+- GPU utilization, memory and temperature, plus process-specific telemetry when
+  the dashboard shares the trainer's PID namespace;
 - recent traceback/error excerpts and live console output;
-- Git commit/branch, task/stage, seed, command line, timestep/device, checkpoint path, configuration files, start/end time and exit code;
+- Git commit/branch, task/stage, seed, command line, timestep/device, checkpoint
+  path, configuration files, start/end time and exit code;
 - a copyable run-information block and downloadable `run-summary.json`;
 - active dashboard configuration plus API health.
 
@@ -33,7 +63,7 @@ From the repository root:
 ```bash
 uv sync --frozen --extra cu128 --extra dashboard
 cd dashboard/frontend
-npm install
+npm ci
 npm run build
 cd ../..
 ```
@@ -65,29 +95,56 @@ available to your tailnet without exposing it on the LAN:
 tailscale serve --bg 8000
 ```
 
-Open the HTTPS Tailscale Serve URL from another device on the same tailnet.
-Do not use Tailscale Funnel for this private monitor.
+Open the HTTPS Tailscale Serve URL from another device on the same tailnet. Do
+not use Tailscale Funnel for this private control surface.
 
-To use a different artifact root:
+The maintained Docker dashboard mounts `logs/` read-write because managed runs
+create their status, logs, TensorBoard files and checkpoints under the shared
+artifact root. `checkpoints/`, `captures/`, and `evaluations/` remain read-only in
+the dashboard service.
+
+## API
+
+Read/monitor endpoints:
+
+- `GET /api/health`
+- `GET /api/config`
+- `GET /api/runs`
+- `GET /api/runs/<id>`
+- `GET /api/runs/<id>/summary.json`
+- `GET /api/runs/<id>/telemetry`
+- `GET /api/runs/<id>/logs`
+- `GET /api/runs/<id>/logs/stream`
+
+Run-control endpoints:
+
+- `POST /api/runs` — start a managed run;
+- `PATCH /api/runs/<id>` — edit name/notes/tags/purpose/lineage;
+- `POST /api/runs/<id>/stop` — request a graceful stop;
+- `GET /api/runs/compare?run_ids=<id1>,<id2>` — compare 2–8 runs.
+
+The Runs page passes training CLI tokens as an explicit string list. In the UI,
+enter one option/value per line so values containing punctuation are not
+re-tokenized by a shell.
+
+## CLI launch
+
+The CLI remains useful for automation and records the same provenance:
 
 ```bash
-ASCENTO_ARTIFACT_ROOT=/path/to/logs \
-  uv run --frozen --extra dashboard python -m uvicorn dashboard.app:app \
-  --host 127.0.0.1 --port 8000
+uv run --frozen --extra cu128 python -m dashboard.launch \
+  --display-name "Recovery baseline after PR83" \
+  --purpose baseline \
+  --tag recovery --tag pr83 \
+  --task Ascento-Recovery-Flat \
+  -- --env.scene.num-envs 512 --agent.max-iterations 10000
 ```
 
-The API exposes:
-
-- `/api/health` — health indicator and startup/configuration diagnostics;
-- `/api/config` — active dashboard configuration;
-- `/api/runs` — discovered runs;
-- `/api/runs/<id>` — detailed run status, health and reproducibility metadata;
-- `/api/runs/<id>/summary.json` — downloadable run summary;
-- `/api/runs/<id>/telemetry` — normalized training telemetry;
-- `/api/runs/<id>/logs` and `/logs/stream` — captured console output.
+Optional lineage can be recorded with `--parent-run-id` and
+`--parent-checkpoint`.
 
 Native RSL-RL TensorBoard event steps are PPO iterations, not environment
-transitions. The normalized telemetry therefore uses `iteration`,
+transitions. Normalized telemetry therefore uses `iteration`,
 `completed_iterations`, and `total_iterations` for progress. When
 `num_steps_per_env` and `scene.num_envs` are available, it also reports
 `environment_steps` and `total_environment_steps`. `Perf/total_fps` is exposed
@@ -96,41 +153,9 @@ as environment-step throughput rather than iteration throughput.
 `ASCENTO_STALE_AFTER_SECONDS` controls the stale-run threshold and defaults to
 90 seconds.
 
-## Start a monitored training run
-
-Launch training through the same uv-managed environment:
-
-```bash
-uv run --frozen --extra cu128 python -m dashboard.launch \
-  --task Ascento-Balance-Flat \
-  -- --env.scene.num-envs 512 --agent.max-iterations 10000
-```
-
-`dashboard.launch` captures durable run metadata before starting the trainer,
-including the current Git commit/branch and exact command. It also updates the
-status record from the trainer's runtime output with the actual seed/device and
-records the launcher's PID namespace so a dashboard in another container does
-not misidentify an unrelated same-numbered PID as the trainer.
-
-To override the shared root for both the launcher and server:
-
-```bash
-ASCENTO_ARTIFACT_ROOT=/path/to/logs \
-  uv run --frozen --extra cu128 python -m dashboard.launch \
-  --task Ascento-Balance-Flat \
-  -- --agent.max-iterations 10000
-```
-
-For motion exports, keep using the normal post-training tooling, for example:
-
-```bash
-uv run --frozen --extra cu128 capture-motion \
-  Ascento-Jump-Flat --checkpoint /path/to/model_10000.pt --takes 20
-```
-
 ## Startup failures
 
 The backend validates its artifact root during startup. If the configured path
-is a file, cannot be created, or cannot be read/searched, startup fails with a
-message naming the bad path and the relevant environment variable. A missing
-frontend build is non-fatal and appears as a startup warning in `/api/health`.
+is a file, cannot be read/searched, or later proves unwritable when starting a
+run, the error names the artifact root. A missing frontend build is non-fatal
+and appears as a startup warning in `/api/health`.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,4 +1,4 @@
-"""FastAPI service for remotely monitoring Ascento PPO training."""
+"""FastAPI service for remotely monitoring and managing Ascento PPO training."""
 from __future__ import annotations
 
 import asyncio
@@ -9,6 +9,7 @@ import time
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
 
 from dashboard.config import load_config, validate_startup
 from dashboard.health import (
@@ -19,16 +20,40 @@ from dashboard.health import (
     summarize_dashboard_run,
 )
 from dashboard.monitor import tail_lines, training_log_path
-from dashboard.versioning import annotate_run_summary, current_repository_version
+from dashboard.run_service import RunService
+from dashboard.versioning import current_repository_version
 
 CONFIG = load_config()
-# The server only monitors artifacts. Docker intentionally mounts logs/checkpoints/
-# captures read-only, so startup validation must never try to create directories.
 STARTUP_WARNINGS = validate_startup(CONFIG, create_artifact_root=False)
 ARTIFACT_ROOT = CONFIG.artifact_root
 FRONTEND_DIST = CONFIG.frontend_dist
+RUN_SERVICE = RunService(ARTIFACT_ROOT, stale_after_seconds=CONFIG.stale_after_seconds)
 
-app = FastAPI(title="Ascento Training Monitor", version="1.3")
+app = FastAPI(title="Ascento Training Monitor", version="2.0")
+
+
+class RunCreateRequest(BaseModel):
+    display_name: str
+    task: str = "Ascento-Balance-Flat"
+    notes: str = ""
+    tags: list[str] = Field(default_factory=list)
+    purpose: str = ""
+    parent_run_id: str | None = None
+    parent_checkpoint: str | None = None
+    training_args: list[str] = Field(default_factory=list)
+
+
+class RunUpdateRequest(BaseModel):
+    display_name: str | None = None
+    notes: str | None = None
+    tags: list[str] | None = None
+    purpose: str | None = None
+    parent_run_id: str | None = None
+    parent_checkpoint: str | None = None
+
+
+class RunStopRequest(BaseModel):
+    reason: str = "user_requested"
 
 
 def _run(run_id: str):
@@ -45,9 +70,6 @@ def _run(run_id: str):
 
 def _artifact_health() -> list[str]:
     problems: list[str] = []
-    # A missing root is normal on a fresh install before the first training run.
-    # discover_runs() treats it as an empty run set, so it is a warning rather
-    # than a health failure.
     if ARTIFACT_ROOT.exists() and not ARTIFACT_ROOT.is_dir():
         problems.append(f"artifact root is not a directory: {ARTIFACT_ROOT}")
     elif ARTIFACT_ROOT.exists():
@@ -67,7 +89,7 @@ def _annotated_summaries() -> list[dict]:
     for summary in summaries:
         ref = refs.get(summary.get("id"))
         if ref is not None:
-            annotate_run_summary(summary, ref.path, ARTIFACT_ROOT)
+            RUN_SERVICE.annotate(summary, ref.path)
     return summaries
 
 
@@ -113,28 +135,63 @@ def runs():
     return {"runs": summaries}
 
 
+@app.post("/api/runs", status_code=202)
+def create_run(request: RunCreateRequest):
+    try:
+        return RUN_SERVICE.create(request.model_dump())
+    except KeyError as error:
+        raise HTTPException(status_code=400, detail=f"parent run not found: {error.args[0]}") from error
+    except (ValueError, PermissionError, OSError) as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@app.get("/api/runs/compare")
+def compare_runs(run_ids: str):
+    ids = [value.strip() for value in run_ids.split(",") if value.strip()]
+    try:
+        return RUN_SERVICE.compare(ids)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"training run not found: {error.args[0]}") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
 @app.get("/api/runs/{run_id}")
 def run_status(run_id: str):
-    ref = _run(run_id)
-    summary = summarize_dashboard_run(
-        ref.path,
-        ARTIFACT_ROOT,
-        stale_after_seconds=CONFIG.stale_after_seconds,
-        detailed=True,
-    )
-    return annotate_run_summary(summary, ref.path, ARTIFACT_ROOT)
+    try:
+        return RUN_SERVICE.detail(run_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="training run not found") from error
+
+
+@app.patch("/api/runs/{run_id}")
+def update_run(run_id: str, request: RunUpdateRequest):
+    try:
+        return RUN_SERVICE.update_metadata(run_id, request.model_dump(exclude_unset=True))
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="training run or parent run not found") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@app.post("/api/runs/{run_id}/stop", status_code=202)
+def stop_run(run_id: str, request: RunStopRequest):
+    try:
+        return RUN_SERVICE.stop(run_id, reason=request.reason.strip() or "user_requested")
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="training run not found") from error
+    except ProcessLookupError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
 
 
 @app.get("/api/runs/{run_id}/summary.json")
 def run_summary(run_id: str):
-    ref = _run(run_id)
-    summary = summarize_dashboard_run(
-        ref.path,
-        ARTIFACT_ROOT,
-        stale_after_seconds=CONFIG.stale_after_seconds,
-        detailed=True,
-    )
-    annotate_run_summary(summary, ref.path, ARTIFACT_ROOT)
+    try:
+        summary = RUN_SERVICE.detail(run_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="training run not found") from error
     return JSONResponse(
         content=summary,
         headers={"Content-Disposition": 'attachment; filename="run-summary.json"'},

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -16,8 +16,6 @@ from dashboard.health import (
     discover_dashboard_runs,
     list_dashboard_summaries,
     load_dashboard_records,
-    resolve_dashboard_run,
-    summarize_dashboard_run,
 )
 from dashboard.monitor import tail_lines, training_log_path
 from dashboard.run_service import RunService
@@ -58,7 +56,7 @@ class RunStopRequest(BaseModel):
 
 def _run(run_id: str):
     try:
-        return resolve_dashboard_run(ARTIFACT_ROOT, run_id)
+        return RUN_SERVICE.resolve(run_id)
     except KeyError as error:
         raise HTTPException(status_code=404, detail="training run not found") from error
     except OSError as error:

--- a/dashboard/frontend/src/Root.jsx
+++ b/dashboard/frontend/src/Root.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import MonitorPage from './App'
+import RunsPage from './RunsPage'
+import './runs.css'
+
+function Root() {
+  const [page, setPage] = useState('runs')
+
+  return (
+    <>
+      <nav className="dashboard-nav">
+        <div className="dashboard-nav-brand">ASCENTO CONTROL</div>
+        <div className="dashboard-nav-tabs">
+          <button className={page === 'runs' ? 'active' : ''} onClick={() => setPage('runs')}>Runs</button>
+          <button className={page === 'monitor' ? 'active' : ''} onClick={() => setPage('monitor')}>Monitor</button>
+        </div>
+      </nav>
+      {page === 'runs' ? <RunsPage /> : <MonitorPage />}
+    </>
+  )
+}
+
+export default Root

--- a/dashboard/frontend/src/RunsPage.jsx
+++ b/dashboard/frontend/src/RunsPage.jsx
@@ -1,0 +1,369 @@
+import { useEffect, useMemo, useState } from 'react'
+
+const POLL_MS = 5000
+const TASKS = [
+  'Ascento-Balance-Flat',
+  'Ascento-Velocity-Flat',
+  'Ascento-Recovery-Flat',
+  'Ascento-Jump-Flat',
+]
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options)
+  const body = await response.json().catch(() => ({}))
+  if (!response.ok) throw new Error(body.detail || `${response.status} ${response.statusText}`)
+  return body
+}
+
+function fmtDate(value) {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString()
+}
+
+function fmtNumber(value, digits = 2) {
+  if (value === null || value === undefined || !Number.isFinite(Number(value))) return '—'
+  return Number(value).toLocaleString(undefined, { maximumFractionDigits: digits })
+}
+
+function shortCommit(value) {
+  return value ? String(value).slice(0, 10) : 'unknown'
+}
+
+function StateBadge({ state }) {
+  return <span className={`runs-state runs-state-${state || 'unknown'}`}>{state || 'unknown'}</span>
+}
+
+function tagList(tags = []) {
+  return tags.length ? tags.join(', ') : '—'
+}
+
+function defaultCreateForm() {
+  return {
+    display_name: '',
+    task: 'Ascento-Balance-Flat',
+    purpose: 'exploratory',
+    tags: '',
+    notes: '',
+    parent_run_id: '',
+    parent_checkpoint: '',
+    training_args: '--env.scene.num-envs\n512\n--agent.max-iterations\n10000',
+  }
+}
+
+function parseArgs(value) {
+  return value.split('\n').map((line) => line.trim()).filter(Boolean)
+}
+
+function RunsPage() {
+  const [runs, setRuns] = useState([])
+  const [selectedId, setSelectedId] = useState('')
+  const [detail, setDetail] = useState(null)
+  const [createForm, setCreateForm] = useState(defaultCreateForm)
+  const [editForm, setEditForm] = useState(null)
+  const [compareIds, setCompareIds] = useState([])
+  const [comparison, setComparison] = useState(null)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  async function refreshRuns() {
+    try {
+      const data = await fetchJson('/api/runs')
+      const next = data.runs || []
+      setRuns(next)
+      setSelectedId((current) => current && next.some((run) => run.id === current) ? current : (next[0]?.id || ''))
+      setError('')
+    } catch (caught) {
+      setError(caught.message)
+    }
+  }
+
+  async function refreshDetail(id) {
+    if (!id) {
+      setDetail(null)
+      return
+    }
+    try {
+      const value = await fetchJson(`/api/runs/${id}`)
+      setDetail(value)
+      setEditForm({
+        display_name: value.display_name || value.name || '',
+        purpose: value.metadata?.purpose || '',
+        tags: (value.tags || []).join(', '),
+        notes: value.notes || '',
+        parent_run_id: value.lineage?.parent_run_id || '',
+        parent_checkpoint: value.lineage?.parent_checkpoint || '',
+      })
+      setError('')
+    } catch (caught) {
+      setError(caught.message)
+    }
+  }
+
+  useEffect(() => {
+    refreshRuns()
+    const timer = setInterval(refreshRuns, POLL_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  useEffect(() => {
+    refreshDetail(selectedId)
+    if (!selectedId) return undefined
+    const timer = setInterval(() => refreshDetail(selectedId), POLL_MS)
+    return () => clearInterval(timer)
+  }, [selectedId])
+
+  const parentOptions = useMemo(
+    () => runs.filter((run) => run.id !== selectedId),
+    [runs, selectedId],
+  )
+
+  async function createRun(event) {
+    event.preventDefault()
+    setBusy(true)
+    setNotice('')
+    try {
+      const payload = {
+        display_name: createForm.display_name,
+        task: createForm.task,
+        purpose: createForm.purpose,
+        tags: createForm.tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+        notes: createForm.notes,
+        parent_run_id: createForm.parent_run_id || null,
+        parent_checkpoint: createForm.parent_checkpoint || null,
+        training_args: parseArgs(createForm.training_args),
+      }
+      const created = await fetchJson('/api/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      setCreateForm(defaultCreateForm())
+      setNotice(`Started ${created.display_name}.`)
+      setSelectedId(created.id)
+      setTimeout(refreshRuns, 500)
+    } catch (caught) {
+      setError(caught.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function saveMetadata(event) {
+    event.preventDefault()
+    if (!selectedId || !editForm) return
+    setBusy(true)
+    setNotice('')
+    try {
+      const updated = await fetchJson(`/api/runs/${selectedId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...editForm,
+          tags: editForm.tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+          parent_run_id: editForm.parent_run_id || null,
+          parent_checkpoint: editForm.parent_checkpoint || null,
+        }),
+      })
+      setDetail(updated)
+      setNotice('Run metadata saved.')
+      refreshRuns()
+    } catch (caught) {
+      setError(caught.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function stopRun() {
+    if (!selectedId) return
+    setBusy(true)
+    setNotice('')
+    try {
+      const updated = await fetchJson(`/api/runs/${selectedId}/stop`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'user_requested' }),
+      })
+      setDetail(updated)
+      setNotice('Graceful stop requested.')
+      refreshRuns()
+    } catch (caught) {
+      setError(caught.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function toggleCompare(id) {
+    setComparison(null)
+    setCompareIds((current) => {
+      if (current.includes(id)) return current.filter((value) => value !== id)
+      if (current.length >= 8) return current
+      return [...current, id]
+    })
+  }
+
+  async function compareRuns() {
+    if (compareIds.length < 2) return
+    setBusy(true)
+    try {
+      const data = await fetchJson(`/api/runs/compare?run_ids=${encodeURIComponent(compareIds.join(','))}`)
+      setComparison(data)
+      setError('')
+    } catch (caught) {
+      setError(caught.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const active = ['starting', 'running', 'stopping'].includes(detail?.state)
+
+  return (
+    <main className="runs-page">
+      <section className="runs-hero">
+        <div>
+          <div className="eyebrow">RUN CONTROL / PROVENANCE</div>
+          <h1>Runs</h1>
+          <p>Start training, label experiments, preserve lineage, stop safely, and compare results from one place.</p>
+        </div>
+        <div className="runs-counts">
+          <div><strong>{runs.length}</strong><span>discovered</span></div>
+          <div><strong>{runs.filter((run) => ['starting', 'running', 'stopping'].includes(run.state)).length}</strong><span>active</span></div>
+          <div><strong>{runs.filter((run) => run.repository_version?.is_outdated).length}</strong><span>outdated</span></div>
+        </div>
+      </section>
+
+      {error && <div className="runs-alert runs-alert-error">{error}</div>}
+      {notice && <div className="runs-alert runs-alert-ok">{notice}</div>}
+
+      <section className="runs-layout">
+        <div className="runs-main-column">
+          <section className="runs-panel">
+            <div className="runs-panel-heading">
+              <div>
+                <h2>Run library</h2>
+                <p>Human names are separate from machine artifact directories. Existing runs can be annotated in place.</p>
+              </div>
+              <button className="runs-button subtle" onClick={refreshRuns}>Refresh</button>
+            </div>
+            <div className="runs-table-wrap">
+              <table className="runs-table">
+                <thead>
+                  <tr>
+                    <th>Compare</th>
+                    <th>Run</th>
+                    <th>State</th>
+                    <th>Stage</th>
+                    <th>Tags</th>
+                    <th>Version</th>
+                    <th>Progress</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {runs.map((run) => (
+                    <tr key={run.id} className={run.id === selectedId ? 'selected' : ''} onClick={() => setSelectedId(run.id)}>
+                      <td onClick={(event) => event.stopPropagation()}>
+                        <input type="checkbox" checked={compareIds.includes(run.id)} onChange={() => toggleCompare(run.id)} />
+                      </td>
+                      <td>
+                        <strong>{run.display_name || run.name}</strong>
+                        <small>{run.name}</small>
+                      </td>
+                      <td><StateBadge state={run.state} /></td>
+                      <td>{run.stage || '—'}</td>
+                      <td>{tagList(run.tags)}</td>
+                      <td>
+                        <span className={run.repository_version?.is_outdated ? 'runs-version-old' : ''}>
+                          {run.repository_version?.status || 'unknown'}
+                        </span>
+                        <small>{shortCommit(run.repository_version?.run_commit)}</small>
+                      </td>
+                      <td>{fmtNumber(run.telemetry?.percent_complete, 1)}%</td>
+                    </tr>
+                  ))}
+                  {runs.length === 0 && <tr><td colSpan="7" className="runs-empty">No runs found yet.</td></tr>}
+                </tbody>
+              </table>
+            </div>
+            <div className="runs-compare-bar">
+              <span>{compareIds.length} selected</span>
+              <button className="runs-button" disabled={compareIds.length < 2 || busy} onClick={compareRuns}>Compare selected</button>
+              {compareIds.length > 0 && <button className="runs-button subtle" onClick={() => { setCompareIds([]); setComparison(null) }}>Clear</button>}
+            </div>
+          </section>
+
+          {comparison && (
+            <section className="runs-panel">
+              <div className="runs-panel-heading"><div><h2>Comparison</h2><p>First selected run is the baseline; deltas are latest normalized telemetry.</p></div></div>
+              <div className="runs-table-wrap">
+                <table className="runs-table comparison-table">
+                  <thead><tr><th>Run</th><th>Reward</th><th>Δ reward</th><th>Episode length</th><th>PPO loss</th><th>KL</th><th>Iteration</th></tr></thead>
+                  <tbody>
+                    {comparison.runs.map((run) => (
+                      <tr key={run.id}>
+                        <td><strong>{run.display_name}</strong>{run.id === comparison.baseline_id && <small>baseline</small>}</td>
+                        <td>{fmtNumber(run.latest_metrics.reward, 4)}</td>
+                        <td>{fmtNumber(run.delta_from_baseline.reward, 4)}</td>
+                        <td>{fmtNumber(run.latest_metrics.episode_length, 2)}</td>
+                        <td>{fmtNumber(run.latest_metrics.ppo_loss, 6)}</td>
+                        <td>{fmtNumber(run.latest_metrics.kl, 6)}</td>
+                        <td>{fmtNumber(run.iteration, 0)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+        </div>
+
+        <aside className="runs-side-column">
+          <section className="runs-panel">
+            <div className="runs-panel-heading"><div><h2>New run</h2><p>Create a managed training process.</p></div></div>
+            <form className="runs-form" onSubmit={createRun}>
+              <label>Human name<input required value={createForm.display_name} onChange={(event) => setCreateForm({ ...createForm, display_name: event.target.value })} placeholder="Recovery baseline after PR83" /></label>
+              <label>Task<select value={createForm.task} onChange={(event) => setCreateForm({ ...createForm, task: event.target.value })}>{TASKS.map((task) => <option key={task}>{task}</option>)}</select></label>
+              <label>Purpose<select value={createForm.purpose} onChange={(event) => setCreateForm({ ...createForm, purpose: event.target.value })}><option>exploratory</option><option>baseline</option><option>tuning</option><option>validation</option><option>regression</option></select></label>
+              <label>Tags<input value={createForm.tags} onChange={(event) => setCreateForm({ ...createForm, tags: event.target.value })} placeholder="recovery, pr83, baseline" /></label>
+              <label>Parent run<select value={createForm.parent_run_id} onChange={(event) => setCreateForm({ ...createForm, parent_run_id: event.target.value })}><option value="">None</option>{runs.map((run) => <option key={run.id} value={run.id}>{run.display_name || run.name}</option>)}</select></label>
+              <label>Parent checkpoint<input value={createForm.parent_checkpoint} onChange={(event) => setCreateForm({ ...createForm, parent_checkpoint: event.target.value })} placeholder="model_7500.pt" /></label>
+              <label>Notes<textarea rows="3" value={createForm.notes} onChange={(event) => setCreateForm({ ...createForm, notes: event.target.value })} placeholder="Why this run exists and what should be learned from it." /></label>
+              <label>Training arguments <small>one argument/value per line</small><textarea className="mono" rows="7" value={createForm.training_args} onChange={(event) => setCreateForm({ ...createForm, training_args: event.target.value })} /></label>
+              <button className="runs-button primary" disabled={busy}>Start training</button>
+            </form>
+          </section>
+
+          {detail && editForm && (
+            <section className="runs-panel">
+              <div className="runs-panel-heading">
+                <div><h2>Selected run</h2><p>{detail.name}</p></div>
+                <StateBadge state={detail.state} />
+              </div>
+              <div className="runs-summary-grid">
+                <div><span>Task</span><strong>{detail.run_info?.task || '—'}</strong></div>
+                <div><span>Iteration</span><strong>{fmtNumber(detail.telemetry?.iteration, 0)}</strong></div>
+                <div><span>Started</span><strong>{fmtDate(detail.run_info?.started_at)}</strong></div>
+                <div><span>Commit</span><strong className="mono">{shortCommit(detail.repository_version?.run_commit)}</strong></div>
+              </div>
+              {active && <button className="runs-button danger full" disabled={busy || detail.state === 'stopping'} onClick={stopRun}>{detail.state === 'stopping' ? 'Stopping…' : 'Graceful stop'}</button>}
+              <form className="runs-form edit-form" onSubmit={saveMetadata}>
+                <label>Human name<input value={editForm.display_name} onChange={(event) => setEditForm({ ...editForm, display_name: event.target.value })} /></label>
+                <label>Purpose<input value={editForm.purpose} onChange={(event) => setEditForm({ ...editForm, purpose: event.target.value })} /></label>
+                <label>Tags<input value={editForm.tags} onChange={(event) => setEditForm({ ...editForm, tags: event.target.value })} /></label>
+                <label>Parent run<select value={editForm.parent_run_id} onChange={(event) => setEditForm({ ...editForm, parent_run_id: event.target.value })}><option value="">None</option>{parentOptions.map((run) => <option key={run.id} value={run.id}>{run.display_name || run.name}</option>)}</select></label>
+                <label>Parent checkpoint<input value={editForm.parent_checkpoint} onChange={(event) => setEditForm({ ...editForm, parent_checkpoint: event.target.value })} /></label>
+                <label>Notes<textarea rows="4" value={editForm.notes} onChange={(event) => setEditForm({ ...editForm, notes: event.target.value })} /></label>
+                <button className="runs-button" disabled={busy}>Save metadata</button>
+              </form>
+            </section>
+          )}
+        </aside>
+      </section>
+    </main>
+  )
+}
+
+export default RunsPage

--- a/dashboard/frontend/src/main.jsx
+++ b/dashboard/frontend/src/main.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.jsx'
+import Root from './Root.jsx'
 import './styles.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 )

--- a/dashboard/frontend/src/runs.css
+++ b/dashboard/frontend/src/runs.css
@@ -1,0 +1,363 @@
+.dashboard-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 12px 28px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.22);
+  background: rgba(12, 14, 18, 0.94);
+  backdrop-filter: blur(14px);
+}
+
+.dashboard-nav-brand {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.dashboard-nav-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.dashboard-nav-tabs button,
+.runs-button {
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 8px;
+  padding: 9px 13px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.dashboard-nav-tabs button.active,
+.runs-button.primary {
+  background: rgba(255, 255, 255, 0.13);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.runs-page {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 28px;
+}
+
+.runs-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  margin-bottom: 20px;
+}
+
+.runs-hero h1 {
+  margin: 4px 0 6px;
+  font-size: 34px;
+}
+
+.runs-hero p,
+.runs-panel-heading p {
+  margin: 0;
+  opacity: 0.68;
+}
+
+.runs-counts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(90px, 1fr));
+  gap: 10px;
+}
+
+.runs-counts div {
+  padding: 14px 16px;
+  border: 1px solid rgba(127, 127, 127, 0.25);
+  border-radius: 10px;
+  min-width: 100px;
+}
+
+.runs-counts strong,
+.runs-counts span {
+  display: block;
+}
+
+.runs-counts strong {
+  font-size: 22px;
+}
+
+.runs-counts span {
+  margin-top: 2px;
+  font-size: 12px;
+  opacity: 0.62;
+}
+
+.runs-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(330px, 0.65fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.runs-main-column,
+.runs-side-column {
+  display: grid;
+  gap: 18px;
+}
+
+.runs-panel {
+  border: 1px solid rgba(127, 127, 127, 0.25);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  padding: 18px;
+}
+
+.runs-panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.runs-panel-heading h2 {
+  margin: 0 0 4px;
+  font-size: 17px;
+}
+
+.runs-panel-heading p {
+  font-size: 12px;
+}
+
+.runs-table-wrap {
+  overflow-x: auto;
+}
+
+.runs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.runs-table th,
+.runs-table td {
+  text-align: left;
+  padding: 11px 10px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.17);
+  vertical-align: top;
+}
+
+.runs-table th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.58;
+}
+
+.runs-table tbody tr {
+  cursor: pointer;
+}
+
+.runs-table tbody tr:hover,
+.runs-table tbody tr.selected {
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.runs-table td strong,
+.runs-table td small {
+  display: block;
+}
+
+.runs-table td small {
+  margin-top: 4px;
+  opacity: 0.55;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.runs-state {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.runs-state-running,
+.runs-state-starting {
+  border-color: rgba(94, 220, 155, 0.7);
+}
+
+.runs-state-stopping {
+  border-color: rgba(235, 190, 88, 0.75);
+}
+
+.runs-state-error {
+  border-color: rgba(240, 104, 104, 0.8);
+}
+
+.runs-version-old {
+  font-weight: 700;
+}
+
+.runs-compare-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 14px;
+}
+
+.runs-compare-bar span {
+  margin-right: auto;
+  font-size: 12px;
+  opacity: 0.65;
+}
+
+.runs-button:disabled,
+.dashboard-nav-tabs button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.runs-button.subtle {
+  background: transparent;
+}
+
+.runs-button.danger {
+  border-color: rgba(240, 104, 104, 0.72);
+}
+
+.runs-button.full {
+  width: 100%;
+  margin-bottom: 14px;
+}
+
+.runs-form {
+  display: grid;
+  gap: 12px;
+}
+
+.runs-form label {
+  display: grid;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.runs-form label small {
+  font-weight: 400;
+  opacity: 0.6;
+}
+
+.runs-form input,
+.runs-form select,
+.runs-form textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(127, 127, 127, 0.34);
+  border-radius: 7px;
+  padding: 9px 10px;
+  background: rgba(0, 0, 0, 0.16);
+  color: inherit;
+  font: inherit;
+}
+
+.runs-form textarea {
+  resize: vertical;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace !important;
+}
+
+.edit-form {
+  padding-top: 14px;
+  border-top: 1px solid rgba(127, 127, 127, 0.18);
+}
+
+.runs-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.runs-summary-grid div {
+  min-width: 0;
+}
+
+.runs-summary-grid span,
+.runs-summary-grid strong {
+  display: block;
+}
+
+.runs-summary-grid span {
+  font-size: 11px;
+  opacity: 0.58;
+}
+
+.runs-summary-grid strong {
+  margin-top: 2px;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.runs-alert {
+  margin-bottom: 16px;
+  padding: 11px 13px;
+  border-radius: 8px;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+}
+
+.runs-alert-error {
+  border-color: rgba(240, 104, 104, 0.72);
+}
+
+.runs-alert-ok {
+  border-color: rgba(94, 220, 155, 0.62);
+}
+
+.runs-empty {
+  padding: 26px !important;
+  text-align: center !important;
+  opacity: 0.6;
+}
+
+.comparison-table tbody tr {
+  cursor: default;
+}
+
+@media (max-width: 1050px) {
+  .runs-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .runs-side-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .dashboard-nav,
+  .runs-hero {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .runs-page {
+    padding: 18px;
+  }
+
+  .runs-counts,
+  .runs-side-column {
+    width: 100%;
+    grid-template-columns: 1fr;
+  }
+
+  .runs-summary-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -11,6 +11,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from dashboard.config import REPO_ROOT, load_config
 
@@ -172,6 +173,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--name", help="run directory name; defaults to timestamp_stage")
     parser.add_argument("--task", default="Ascento-Balance-Flat")
+    parser.add_argument("--run-id", help="stable dashboard run id; generated automatically when omitted")
     parser.add_argument("--display-name", help="human-readable run name shown by the dashboard")
     parser.add_argument("--notes", default="", help="human notes stored with the run")
     parser.add_argument("--tag", action="append", default=[], help="repeatable run tag")
@@ -237,10 +239,12 @@ def main() -> int:
     started = datetime.now(timezone.utc).isoformat()
     git = git_metadata()
     display_name = (args.display_name or run_name).strip()
+    stable_run_id = (args.run_id or uuid4().hex[:12]).strip()
     tags = list(dict.fromkeys(tag.strip() for tag in args.tag if tag.strip()))
 
     write_metadata(
         metadata_path,
+        run_id=stable_run_id,
         display_name=display_name,
         notes=args.notes.strip(),
         tags=tags,
@@ -257,6 +261,7 @@ def main() -> int:
         status_path,
         schema_version=4,
         state="starting",
+        run_id=stable_run_id,
         task=args.task,
         stage=stage,
         display_name=display_name,

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -29,6 +30,22 @@ def write_status(path: Path, **values: Any) -> None:
     current.update(values)
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(current, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_metadata(path: Path, **values: Any) -> None:
+    current: dict[str, Any] = {}
+    if path.exists():
+        try:
+            current = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            current = {}
+    current.update(values)
+    current["updated_at"] = datetime.now(timezone.utc).isoformat()
+    current.setdefault("created_at", current["updated_at"])
+    current.setdefault("schema_version", 1)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(current, indent=2, sort_keys=True), encoding="utf-8")
     tmp.replace(path)
 
 
@@ -155,6 +172,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--name", help="run directory name; defaults to timestamp_stage")
     parser.add_argument("--task", default="Ascento-Balance-Flat")
+    parser.add_argument("--display-name", help="human-readable run name shown by the dashboard")
+    parser.add_argument("--notes", default="", help="human notes stored with the run")
+    parser.add_argument("--tag", action="append", default=[], help="repeatable run tag")
+    parser.add_argument("--purpose", default="", help="run purpose, e.g. baseline or validation")
+    parser.add_argument("--parent-run-id", help="dashboard id of the parent run")
+    parser.add_argument("--parent-checkpoint", help="checkpoint inherited from the parent run")
     parser.add_argument("training_args", nargs=argparse.REMAINDER)
     return parser
 
@@ -182,6 +205,7 @@ def main() -> int:
         parser.error(f"cannot create run directory {run_dir}: {error}")
 
     status_path = run_dir / "run_status.json"
+    metadata_path = run_dir / "run_metadata.json"
     log_path = run_dir / "training.log"
     command = [
         sys.executable,
@@ -212,13 +236,30 @@ def main() -> int:
     )
     started = datetime.now(timezone.utc).isoformat()
     git = git_metadata()
+    display_name = (args.display_name or run_name).strip()
+    tags = list(dict.fromkeys(tag.strip() for tag in args.tag if tag.strip()))
 
+    write_metadata(
+        metadata_path,
+        display_name=display_name,
+        notes=args.notes.strip(),
+        tags=tags,
+        purpose=args.purpose.strip(),
+        parent_run_id=args.parent_run_id,
+        parent_checkpoint=args.parent_checkpoint,
+    )
+
+    # The API starts launchers in a new session so their process group can be
+    # signalled without touching uvicorn. Direct CLI launches are still safe:
+    # they simply omit process_group and the launcher forwards SIGINT itself.
+    process_group = os.getpgrp() if os.getpid() == os.getpgrp() else None
     write_status(
         status_path,
-        schema_version=3,
+        schema_version=4,
         state="starting",
         task=args.task,
         stage=stage,
+        display_name=display_name,
         seed=seed,
         device=device,
         simulation_timestep=sim_timestep,
@@ -231,11 +272,16 @@ def main() -> int:
         git=git,
         git_commit=git.get("commit"),
         git_branch=git.get("branch"),
+        launcher_pid=os.getpid(),
+        process_group=process_group,
         pid_namespace=_pid_namespace(),
         exit_code=None,
+        stop_requested_at=None,
+        stop_reason=None,
     )
 
     exit_code = 127
+    stop_requested = False
     try:
         with log_path.open("a", encoding="utf-8", buffering=1) as log:
             log.write("DASHBOARD_LAUNCH " + " ".join(command) + "\n")
@@ -273,16 +319,23 @@ def main() -> int:
                         write_status(status_path, **runtime_values)
                 exit_code = process.wait()
             except KeyboardInterrupt:
-                process.terminate()
-                exit_code = process.wait()
-                write_status(
-                    status_path,
-                    state="cancelled",
-                    exit_code=exit_code,
-                    finished_at=datetime.now(timezone.utc).isoformat(),
-                    checkpoint_path=_latest_checkpoint(run_dir),
-                )
-                raise
+                stop_requested = True
+                # SIGINT is the graceful request for both native and API-managed
+                # launches. Give the trainer time to run its interrupt cleanup
+                # before escalating to terminate/kill.
+                try:
+                    process.send_signal(signal.SIGINT)
+                except ProcessLookupError:
+                    pass
+                try:
+                    exit_code = process.wait(timeout=30)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    try:
+                        exit_code = process.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        exit_code = process.wait()
     except OSError as error:
         message = f"Dashboard launcher cannot write {log_path}: {error}"
         print(message, file=sys.stderr)
@@ -296,15 +349,16 @@ def main() -> int:
         return 127
 
     finished = datetime.now(timezone.utc).isoformat()
-    state = "finished" if exit_code == 0 else "error"
+    state = "stopped" if stop_requested else ("finished" if exit_code == 0 else "error")
     write_status(
         status_path,
         state=state,
         exit_code=exit_code,
         finished_at=finished,
         checkpoint_path=_latest_checkpoint(run_dir),
+        stop_reason="user_requested" if stop_requested else None,
     )
-    return exit_code
+    return 130 if stop_requested else exit_code
 
 
 if __name__ == "__main__":

--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -8,13 +8,12 @@ import signal
 import subprocess
 import sys
 from datetime import datetime, timezone
-from hashlib import sha1
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 from dashboard.config import REPO_ROOT
-from dashboard.health import resolve_dashboard_run, run_status_path, summarize_dashboard_run
+from dashboard.health import discover_dashboard_runs, run_status_path, summarize_dashboard_run
 from dashboard.versioning import annotate_run_summary
 
 RUN_METADATA = "run_metadata.json"
@@ -27,10 +26,6 @@ def _now() -> str:
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return slug[:48] or "run"
-
-
-def _run_id(relative_path: str) -> str:
-    return sha1(relative_path.encode("utf-8")).hexdigest()[:12]
 
 
 def _inside(path: Path, root: Path) -> bool:
@@ -90,6 +85,7 @@ class RunService:
     def load_metadata(self, run_dir: Path) -> dict[str, Any]:
         metadata = _load_json(self.metadata_path(run_dir))
         return {
+            "run_id": metadata.get("run_id"),
             "display_name": metadata.get("display_name") or run_dir.name,
             "notes": metadata.get("notes") or "",
             "tags": _clean_tags(metadata.get("tags") if isinstance(metadata.get("tags"), list) else []),
@@ -101,8 +97,20 @@ class RunService:
             "schema_version": int(metadata.get("schema_version") or 1),
         }
 
+    def resolve(self, run_id: str):
+        for ref in discover_dashboard_runs(self.artifact_root):
+            metadata = self.load_metadata(ref.path)
+            if ref.id == run_id or metadata.get("run_id") == run_id:
+                return ref
+        raise KeyError(run_id)
+
     def annotate(self, summary: dict[str, Any], run_dir: Path) -> dict[str, Any]:
         metadata = self.load_metadata(run_dir)
+        legacy_id = summary.get("id")
+        if metadata.get("run_id"):
+            summary["id"] = metadata["run_id"]
+            if legacy_id != summary["id"]:
+                summary["legacy_id"] = legacy_id
         summary["metadata"] = metadata
         summary["display_name"] = metadata["display_name"]
         summary["notes"] = metadata["notes"]
@@ -114,7 +122,7 @@ class RunService:
         return annotate_run_summary(summary, run_dir, self.artifact_root)
 
     def detail(self, run_id: str) -> dict[str, Any]:
-        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        ref = self.resolve(run_id)
         summary = summarize_dashboard_run(
             ref.path,
             self.artifact_root,
@@ -124,12 +132,13 @@ class RunService:
         return self.annotate(summary, ref.path)
 
     def update_metadata(self, run_id: str, changes: dict[str, Any]) -> dict[str, Any]:
-        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        ref = self.resolve(run_id)
         path = self.metadata_path(ref.path)
         current = _load_json(path)
         if not current:
             current = {
                 "schema_version": 1,
+                "run_id": run_id,
                 "created_at": _now(),
                 "display_name": ref.path.name,
                 "notes": "",
@@ -138,6 +147,8 @@ class RunService:
                 "parent_run_id": None,
                 "parent_checkpoint": None,
             }
+        else:
+            current.setdefault("run_id", run_id)
 
         for key in ("display_name", "notes", "purpose", "parent_checkpoint"):
             if key in changes and changes[key] is not None:
@@ -149,13 +160,13 @@ class RunService:
             if parent:
                 if str(parent) == run_id:
                     raise ValueError("a run cannot be its own parent")
-                resolve_dashboard_run(self.artifact_root, str(parent))
+                self.resolve(str(parent))
                 current["parent_run_id"] = str(parent)
             else:
                 current["parent_run_id"] = None
         current["updated_at"] = _now()
         _write_json(path, current)
-        return self.detail(run_id)
+        return self.detail(str(current["run_id"]))
 
     def create(self, request: dict[str, Any]) -> dict[str, Any]:
         display_name = str(request.get("display_name") or "").strip()
@@ -169,14 +180,15 @@ class RunService:
             raise ValueError("training_args must be a list of strings")
         parent_run_id = request.get("parent_run_id")
         if parent_run_id:
-            resolve_dashboard_run(self.artifact_root, str(parent_run_id))
+            self.resolve(str(parent_run_id))
 
         self.artifact_root.mkdir(parents=True, exist_ok=True)
         if not os.access(self.artifact_root, os.W_OK | os.X_OK):
             raise PermissionError(f"artifact root is not writable: {self.artifact_root}")
 
+        stable_run_id = uuid4().hex[:12]
         stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        directory_name = f"{stamp}_{_slug(display_name)}_{uuid4().hex[:8]}"
+        directory_name = f"{stamp}_{_slug(display_name)}_{stable_run_id[:8]}"
         command = [
             sys.executable,
             "-m",
@@ -187,6 +199,8 @@ class RunService:
             directory_name,
             "--task",
             task,
+            "--run-id",
+            stable_run_id,
             "--display-name",
             display_name,
         ]
@@ -216,7 +230,7 @@ class RunService:
             close_fds=True,
         )
         return {
-            "id": _run_id(directory_name),
+            "id": stable_run_id,
             "name": directory_name,
             "display_name": display_name,
             "task": task,
@@ -226,7 +240,7 @@ class RunService:
         }
 
     def stop(self, run_id: str, *, reason: str = "user_requested") -> dict[str, Any]:
-        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        ref = self.resolve(run_id)
         status_path = run_status_path(ref.path, self.artifact_root)
         status = _load_json(status_path)
         state = str(status.get("state") or "unknown")

--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -1,0 +1,288 @@
+"""Run lifecycle, provenance metadata, and comparison services for the dashboard."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+from hashlib import sha1
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dashboard.config import REPO_ROOT
+from dashboard.health import resolve_dashboard_run, summarize_dashboard_run
+from dashboard.versioning import annotate_run_summary
+
+RUN_METADATA = "run_metadata.json"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:48] or "run"
+
+
+def _run_id(relative_path: str) -> str:
+    return sha1(relative_path.encode("utf-8")).hexdigest()[:12]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    temporary.replace(path)
+
+
+def _clean_tags(tags: list[str] | None) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for tag in tags or []:
+        cleaned = str(tag).strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned[:64])
+    return result[:32]
+
+
+class RunService:
+    """Filesystem-backed run controller used by the dashboard API."""
+
+    def __init__(self, artifact_root: Path, *, stale_after_seconds: float = 90.0):
+        self.artifact_root = artifact_root.expanduser().resolve()
+        self.stale_after_seconds = stale_after_seconds
+
+    def metadata_path(self, run_dir: Path) -> Path:
+        return run_dir / RUN_METADATA
+
+    def load_metadata(self, run_dir: Path) -> dict[str, Any]:
+        metadata = _load_json(self.metadata_path(run_dir))
+        return {
+            "display_name": metadata.get("display_name") or run_dir.name,
+            "notes": metadata.get("notes") or "",
+            "tags": _clean_tags(metadata.get("tags") if isinstance(metadata.get("tags"), list) else []),
+            "purpose": metadata.get("purpose") or "",
+            "parent_run_id": metadata.get("parent_run_id"),
+            "parent_checkpoint": metadata.get("parent_checkpoint"),
+            "created_at": metadata.get("created_at"),
+            "updated_at": metadata.get("updated_at"),
+            "schema_version": int(metadata.get("schema_version") or 1),
+        }
+
+    def annotate(self, summary: dict[str, Any], run_dir: Path) -> dict[str, Any]:
+        metadata = self.load_metadata(run_dir)
+        summary["metadata"] = metadata
+        summary["display_name"] = metadata["display_name"]
+        summary["notes"] = metadata["notes"]
+        summary["tags"] = metadata["tags"]
+        summary["lineage"] = {
+            "parent_run_id": metadata.get("parent_run_id"),
+            "parent_checkpoint": metadata.get("parent_checkpoint"),
+        }
+        return annotate_run_summary(summary, run_dir, self.artifact_root)
+
+    def detail(self, run_id: str) -> dict[str, Any]:
+        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        summary = summarize_dashboard_run(
+            ref.path,
+            self.artifact_root,
+            stale_after_seconds=self.stale_after_seconds,
+            detailed=True,
+        )
+        return self.annotate(summary, ref.path)
+
+    def update_metadata(self, run_id: str, changes: dict[str, Any]) -> dict[str, Any]:
+        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        path = self.metadata_path(ref.path)
+        current = _load_json(path)
+        if not current:
+            current = {
+                "schema_version": 1,
+                "created_at": _now(),
+                "display_name": ref.path.name,
+                "notes": "",
+                "tags": [],
+                "purpose": "",
+                "parent_run_id": None,
+                "parent_checkpoint": None,
+            }
+
+        for key in ("display_name", "notes", "purpose", "parent_checkpoint"):
+            if key in changes and changes[key] is not None:
+                current[key] = str(changes[key]).strip()
+        if "tags" in changes and changes["tags"] is not None:
+            current["tags"] = _clean_tags(changes["tags"])
+        if "parent_run_id" in changes:
+            parent = changes["parent_run_id"]
+            if parent:
+                if str(parent) == run_id:
+                    raise ValueError("a run cannot be its own parent")
+                resolve_dashboard_run(self.artifact_root, str(parent))
+                current["parent_run_id"] = str(parent)
+            else:
+                current["parent_run_id"] = None
+        current["updated_at"] = _now()
+        _write_json(path, current)
+        return self.detail(run_id)
+
+    def create(self, request: dict[str, Any]) -> dict[str, Any]:
+        display_name = str(request.get("display_name") or "").strip()
+        if not display_name:
+            raise ValueError("display_name is required")
+        task = str(request.get("task") or "Ascento-Balance-Flat").strip()
+        if not task.startswith("Ascento-"):
+            raise ValueError("task must be an Ascento task name")
+        training_args = request.get("training_args") or []
+        if not isinstance(training_args, list) or not all(isinstance(value, str) for value in training_args):
+            raise ValueError("training_args must be a list of strings")
+        parent_run_id = request.get("parent_run_id")
+        if parent_run_id:
+            resolve_dashboard_run(self.artifact_root, str(parent_run_id))
+
+        self.artifact_root.mkdir(parents=True, exist_ok=True)
+        if not os.access(self.artifact_root, os.W_OK | os.X_OK):
+            raise PermissionError(f"artifact root is not writable: {self.artifact_root}")
+
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        directory_name = f"{stamp}_{_slug(display_name)}_{uuid4().hex[:8]}"
+        command = [
+            sys.executable,
+            "-m",
+            "dashboard.launch",
+            "--artifact-root",
+            str(self.artifact_root),
+            "--name",
+            directory_name,
+            "--task",
+            task,
+            "--display-name",
+            display_name,
+        ]
+        notes = str(request.get("notes") or "").strip()
+        purpose = str(request.get("purpose") or "").strip()
+        parent_checkpoint = str(request.get("parent_checkpoint") or "").strip()
+        if notes:
+            command.extend(["--notes", notes])
+        if purpose:
+            command.extend(["--purpose", purpose])
+        if parent_run_id:
+            command.extend(["--parent-run-id", str(parent_run_id)])
+        if parent_checkpoint:
+            command.extend(["--parent-checkpoint", parent_checkpoint])
+        for tag in _clean_tags(request.get("tags")):
+            command.extend(["--tag", tag])
+        command.append("--")
+        command.extend(training_args)
+
+        process = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        return {
+            "id": _run_id(directory_name),
+            "name": directory_name,
+            "display_name": display_name,
+            "task": task,
+            "state": "starting",
+            "launcher_pid": process.pid,
+            "created_at": _now(),
+        }
+
+    def stop(self, run_id: str, *, reason: str = "user_requested") -> dict[str, Any]:
+        ref = resolve_dashboard_run(self.artifact_root, run_id)
+        status_path = ref.path / "run_status.json"
+        status = _load_json(status_path)
+        state = str(status.get("state") or "unknown")
+        if state not in {"starting", "running", "stopping"}:
+            raise ValueError(f"run is not active (state={state})")
+
+        status.update(
+            {
+                "state": "stopping",
+                "stop_requested_at": _now(),
+                "stop_reason": reason,
+            }
+        )
+        _write_json(status_path, status)
+
+        pgid = status.get("process_group")
+        launcher_pid = status.get("launcher_pid")
+        trainer_pid = status.get("pid")
+        try:
+            if isinstance(pgid, int) and pgid > 0:
+                os.killpg(pgid, signal.SIGINT)
+            elif isinstance(launcher_pid, int) and launcher_pid > 0:
+                os.kill(launcher_pid, signal.SIGINT)
+            elif isinstance(trainer_pid, int) and trainer_pid > 0:
+                os.kill(trainer_pid, signal.SIGINT)
+            else:
+                raise ProcessLookupError("no controllable process id recorded")
+        except ProcessLookupError as error:
+            status.update(
+                {
+                    "state": "error",
+                    "control_error": str(error),
+                    "finished_at": _now(),
+                }
+            )
+            _write_json(status_path, status)
+            raise
+        return self.detail(run_id)
+
+    def compare(self, run_ids: list[str]) -> dict[str, Any]:
+        unique = list(dict.fromkeys(run_ids))
+        if len(unique) < 2:
+            raise ValueError("compare requires at least two runs")
+        if len(unique) > 8:
+            raise ValueError("compare supports at most eight runs")
+
+        runs = [self.detail(run_id) for run_id in unique]
+        metric_names = ("reward", "episode_length", "ppo_loss", "entropy", "kl", "clip_fraction")
+        baseline_latest = (runs[0].get("training_health") or {}).get("latest") or {}
+        comparison: list[dict[str, Any]] = []
+        for run in runs:
+            latest = (run.get("training_health") or {}).get("latest") or {}
+            deltas: dict[str, float | None] = {}
+            for metric in metric_names:
+                base = baseline_latest.get(metric)
+                value = latest.get(metric)
+                if isinstance(base, (int, float)) and isinstance(value, (int, float)):
+                    deltas[metric] = float(value) - float(base)
+                else:
+                    deltas[metric] = None
+            progress = run.get("telemetry") or {}
+            comparison.append(
+                {
+                    "id": run.get("id"),
+                    "display_name": run.get("display_name"),
+                    "state": run.get("state"),
+                    "stage": run.get("stage"),
+                    "tags": run.get("tags") or [],
+                    "repository_version": run.get("repository_version"),
+                    "iteration": progress.get("iteration"),
+                    "percent_complete": progress.get("percent_complete"),
+                    "latest_metrics": {name: latest.get(name) for name in metric_names},
+                    "delta_from_baseline": deltas,
+                }
+            )
+        return {"baseline_id": unique[0], "runs": comparison}

--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -14,7 +14,7 @@ from typing import Any
 from uuid import uuid4
 
 from dashboard.config import REPO_ROOT
-from dashboard.health import resolve_dashboard_run, summarize_dashboard_run
+from dashboard.health import resolve_dashboard_run, run_status_path, summarize_dashboard_run
 from dashboard.versioning import annotate_run_summary
 
 RUN_METADATA = "run_metadata.json"
@@ -31,6 +31,14 @@ def _slug(value: str) -> str:
 
 def _run_id(relative_path: str) -> str:
     return sha1(relative_path.encode("utf-8")).hexdigest()[:12]
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -68,6 +76,15 @@ class RunService:
         self.stale_after_seconds = stale_after_seconds
 
     def metadata_path(self, run_dir: Path) -> Path:
+        """Find launcher-level metadata even when RSL-RL artifacts are nested below it."""
+        for directory in (run_dir.resolve(), *run_dir.resolve().parents):
+            if not _inside(directory, self.artifact_root):
+                break
+            candidate = directory / RUN_METADATA
+            if candidate.is_file():
+                return candidate
+            if directory == self.artifact_root:
+                break
         return run_dir / RUN_METADATA
 
     def load_metadata(self, run_dir: Path) -> dict[str, Any]:
@@ -210,7 +227,7 @@ class RunService:
 
     def stop(self, run_id: str, *, reason: str = "user_requested") -> dict[str, Any]:
         ref = resolve_dashboard_run(self.artifact_root, run_id)
-        status_path = ref.path / "run_status.json"
+        status_path = run_status_path(ref.path, self.artifact_root)
         status = _load_json(status_path)
         state = str(status.get("state") or "unknown")
         if state not in {"starting", "running", "stopping"}:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -31,7 +31,9 @@ services:
     ports:
       - "127.0.0.1:${ASCENTO_DASHBOARD_PORT:-8000}:8000"
     volumes:
-      - ../logs:/workspace/logs:ro
+      # Run management writes launcher metadata, logs and checkpoints beneath
+      # the shared artifact root. Other repository artifacts stay read-only.
+      - ../logs:/workspace/logs
       - ../checkpoints:/workspace/checkpoints:ro
       - ../captures:/workspace/captures:ro
       - ../evaluations:/workspace/evaluations:ro

--- a/tests_dashboard/test_run_api.py
+++ b/tests_dashboard/test_run_api.py
@@ -1,0 +1,49 @@
+import importlib
+
+
+def _load_app(monkeypatch, artifact_root):
+    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(artifact_root))
+    import dashboard.app as dashboard_app
+
+    return importlib.reload(dashboard_app)
+
+
+def test_run_management_routes_are_registered(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+    methods = {
+        (route.path, method)
+        for route in module.app.routes
+        for method in getattr(route, "methods", set())
+    }
+
+    assert ("/api/runs", "POST") in methods
+    assert ("/api/runs/{run_id}", "PATCH") in methods
+    assert ("/api/runs/{run_id}/stop", "POST") in methods
+    assert ("/api/runs/compare", "GET") in methods
+
+
+def test_create_request_preserves_lineage_and_training_args(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+    captured = {}
+
+    def fake_create(payload):
+        captured.update(payload)
+        return {"id": "abc", "state": "starting"}
+
+    monkeypatch.setattr(module.RUN_SERVICE, "create", fake_create)
+    request = module.RunCreateRequest(
+        display_name="Recovery validation",
+        task="Ascento-Recovery-Flat",
+        tags=["recovery", "validation"],
+        parent_run_id="parent123",
+        parent_checkpoint="model_7500.pt",
+        training_args=["--agent.max-iterations", "12000"],
+    )
+
+    result = module.create_run(request)
+
+    assert result["id"] == "abc"
+    assert captured["display_name"] == "Recovery validation"
+    assert captured["parent_run_id"] == "parent123"
+    assert captured["parent_checkpoint"] == "model_7500.pt"
+    assert captured["training_args"][-1] == "12000"

--- a/tests_dashboard/test_run_service.py
+++ b/tests_dashboard/test_run_service.py
@@ -26,10 +26,16 @@ def _run(root: Path, name: str, *, state: str = "finished", reward: float | None
     return run
 
 
+def service_compare_ids(service: RunService, root: Path):
+    from dashboard.health import discover_dashboard_runs
+
+    return [ref.id for ref in discover_dashboard_runs(root)]
+
+
 def test_metadata_can_annotate_existing_runs(tmp_path):
     run = _run(tmp_path, "legacy")
     service = RunService(tmp_path)
-    run_id = service.detail(next(iter(service_compare_ids(service, tmp_path))))["id"]
+    run_id = service_compare_ids(service, tmp_path)[0]
 
     updated = service.update_metadata(
         run_id,
@@ -48,10 +54,30 @@ def test_metadata_can_annotate_existing_runs(tmp_path):
     assert updated["notes"] == "Known-good comparison run."
 
 
-def service_compare_ids(service: RunService, root: Path):
-    from dashboard.health import discover_dashboard_runs
+def test_nested_training_artifacts_use_launcher_metadata(tmp_path):
+    launcher = tmp_path / "managed"
+    launcher.mkdir()
+    (launcher / "run_status.json").write_text(
+        json.dumps({"state": "finished", "task": "Ascento-Recovery-Flat", "stage": "recovery"}),
+        encoding="utf-8",
+    )
+    (launcher / "run_metadata.json").write_text(
+        json.dumps({"display_name": "Managed recovery", "tags": ["recovery"]}),
+        encoding="utf-8",
+    )
+    nested = launcher / "ascento_recovery" / "2026-09-05_12-00-00"
+    nested.mkdir(parents=True)
+    (nested / "telemetry.jsonl").write_text(
+        json.dumps({"completed_steps": 1, "total_steps": 10, "wall_time": 1, "metrics": {}}) + "\n",
+        encoding="utf-8",
+    )
 
-    return [ref.id for ref in discover_dashboard_runs(root)]
+    service = RunService(tmp_path)
+    run_id = service_compare_ids(service, tmp_path)[0]
+    detail = service.detail(run_id)
+
+    assert detail["display_name"] == "Managed recovery"
+    assert detail["tags"] == ["recovery"]
 
 
 def test_lineage_rejects_self_parent_and_accepts_other_run(tmp_path):

--- a/tests_dashboard/test_run_service.py
+++ b/tests_dashboard/test_run_service.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dashboard.run_service import RunService
+
+
+def _run(root: Path, name: str, *, state: str = "finished", reward: float | None = None) -> Path:
+    run = root / name
+    run.mkdir(parents=True)
+    status = {
+        "state": state,
+        "task": "Ascento-Balance-Flat",
+        "stage": "balance",
+        "git_commit": "abc123",
+    }
+    if state in {"starting", "running"}:
+        status.update({"launcher_pid": 12345, "process_group": 12345})
+    (run / "run_status.json").write_text(json.dumps(status), encoding="utf-8")
+    if reward is not None:
+        (run / "telemetry.jsonl").write_text(
+            json.dumps({"completed_steps": 4, "total_steps": 10, "wall_time": 1, "metrics": {"Train/mean_reward": reward}}) + "\n",
+            encoding="utf-8",
+        )
+    return run
+
+
+def test_metadata_can_annotate_existing_runs(tmp_path):
+    run = _run(tmp_path, "legacy")
+    service = RunService(tmp_path)
+    run_id = service.detail(next(iter(service_compare_ids(service, tmp_path))))["id"]
+
+    updated = service.update_metadata(
+        run_id,
+        {
+            "display_name": "Recovery baseline after PR83",
+            "notes": "Known-good comparison run.",
+            "tags": ["recovery", "baseline", "recovery"],
+            "purpose": "baseline",
+        },
+    )
+
+    metadata = json.loads((run / "run_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["display_name"] == "Recovery baseline after PR83"
+    assert metadata["tags"] == ["recovery", "baseline"]
+    assert updated["display_name"] == "Recovery baseline after PR83"
+    assert updated["notes"] == "Known-good comparison run."
+
+
+def service_compare_ids(service: RunService, root: Path):
+    from dashboard.health import discover_dashboard_runs
+
+    return [ref.id for ref in discover_dashboard_runs(root)]
+
+
+def test_lineage_rejects_self_parent_and_accepts_other_run(tmp_path):
+    _run(tmp_path, "parent")
+    _run(tmp_path, "child")
+    service = RunService(tmp_path)
+    ids = {service.detail(run_id)["name"]: run_id for run_id in service_compare_ids(service, tmp_path)}
+
+    with pytest.raises(ValueError, match="own parent"):
+        service.update_metadata(ids["child"], {"parent_run_id": ids["child"]})
+
+    detail = service.update_metadata(
+        ids["child"],
+        {"parent_run_id": ids["parent"], "parent_checkpoint": "model_7500.pt"},
+    )
+    assert detail["lineage"] == {
+        "parent_run_id": ids["parent"],
+        "parent_checkpoint": "model_7500.pt",
+    }
+
+
+def test_create_starts_detached_launcher_with_metadata_arguments(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeProcess:
+        pid = 4321
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr("dashboard.run_service.subprocess.Popen", fake_popen)
+    service = RunService(tmp_path)
+
+    created = service.create(
+        {
+            "display_name": "Velocity validation",
+            "task": "Ascento-Velocity-Flat",
+            "purpose": "validation",
+            "tags": ["velocity", "gate"],
+            "notes": "Verify the current gate.",
+            "training_args": ["--agent.max-iterations", "5000"],
+        }
+    )
+
+    command = captured["command"]
+    assert created["display_name"] == "Velocity validation"
+    assert created["launcher_pid"] == 4321
+    assert "dashboard.launch" in command
+    assert "--display-name" in command
+    assert "Velocity validation" in command
+    assert command[-2:] == ["--agent.max-iterations", "5000"]
+    assert captured["kwargs"]["start_new_session"] is True
+
+
+def test_stop_marks_stopping_before_signalling(monkeypatch, tmp_path):
+    run = _run(tmp_path, "active", state="running")
+    service = RunService(tmp_path)
+    run_id = service_compare_ids(service, tmp_path)[0]
+    calls = []
+
+    monkeypatch.setattr("dashboard.run_service.os.killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    monkeypatch.setattr("dashboard.health.os.kill", lambda pid, sig: None)
+
+    result = service.stop(run_id, reason="plateau")
+    stored = json.loads((run / "run_status.json").read_text(encoding="utf-8"))
+
+    assert calls and calls[0][0] == 12345
+    assert stored["state"] == "stopping"
+    assert stored["stop_reason"] == "plateau"
+    assert result["state"] == "stopping"
+
+
+def test_compare_uses_normalized_metrics_and_baseline_deltas(tmp_path):
+    _run(tmp_path, "first", reward=2.0)
+    _run(tmp_path, "second", reward=3.5)
+    service = RunService(tmp_path)
+    ids = service_compare_ids(service, tmp_path)
+    by_name = {service.detail(run_id)["name"]: run_id for run_id in ids}
+
+    result = service.compare([by_name["first"], by_name["second"]])
+    rows = {row["display_name"]: row for row in result["runs"]}
+
+    assert result["baseline_id"] == by_name["first"]
+    assert rows["first"]["latest_metrics"]["reward"] == 2.0
+    assert rows["second"]["delta_from_baseline"]["reward"] == pytest.approx(1.5)


### PR DESCRIPTION
## Summary

Turn the dashboard from a read-only monitor into the first run-management control plane.

### Backend / lifecycle
- add `RunService` for managed launch, metadata, lineage, stop, stable IDs, and comparison;
- add `POST /api/runs`, `PATCH /api/runs/{id}`, `POST /api/runs/{id}/stop`, and `GET /api/runs/compare`;
- keep legacy run IDs readable while giving managed runs stable IDs stored in `run_metadata.json`;
- resolve launcher-level status/metadata even when RSL-RL creates nested experiment/timestamp directories;
- launch managed runs in their own process session and record launcher PID/process group;
- graceful stop uses SIGINT first, waits for trainer cleanup, then escalates only if needed;
- extend `dashboard.launch` with human name, notes, tags, purpose, parent run/checkpoint, and stable run ID provenance.

### UI
- add a dedicated Runs page and dashboard navigation;
- start runs from the browser;
- annotate both new and legacy runs with human names, notes, tags, purpose, and lineage;
- select 2–8 runs and compare normalized training metrics;
- stop active managed runs from the UI;
- keep the existing Monitor page intact.

### Docker / docs
- make only the dashboard's shared `logs/` mount writable so managed runs can create their own artifacts;
- keep checkpoints/captures/evaluations mounts read-only;
- document the new API, CLI metadata flags, provenance schema, and stop behavior.

### Tests
- lifecycle/provenance tests for metadata, lineage, nested launcher layouts, detached launch, graceful stop, and metric comparison;
- API route/request coverage.

This intentionally does not add the repository-update supervisor or live policy preview yet; those remain follow-up passes after run management is stable.