### PR TITLE
Close pre-long-run correctness blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ uv run --extra cu128 python -m ascento_mjlab.tools.inspect_model
 uv run --extra cu128 pytest -q
 ```
 
+Immediately before committing to a long run, use the production host and the
+actual balance, velocity, and recovery checkpoints to run the complete preflight:
+
+```bash
+export ASCENTO_BALANCE_CHECKPOINT=logs/rsl_rl/ascento_balance/<run>/model_<n>.pt
+export ASCENTO_VELOCITY_CHECKPOINT=logs/rsl_rl/ascento_velocity/<run>/model_<n>.pt
+export ASCENTO_RECOVERY_CHECKPOINT=logs/rsl_rl/ascento_recovery/<run>/model_<n>.pt
+export ASCENTO_COMPUTE_EXTRA=cu128
+bash scripts/preflight_long_run.sh
+```
+
+That command runs the finite plant smoke test, model inspection, the full test
+suite, a two-iteration 512-environment PPO smoke using the production training
+path, and deterministic quantitative evaluator preflight. The evaluator runs the
+same scenarios twice and fails on non-finite outputs, ambiguous episode endings,
+unfinished vector slots, mixed-horizon lifecycle errors, or deterministic result
+drift. Do not launch a long run if this command fails.
+
 The smoke command prints Torch/CUDA/GPU/VRAM, MuJoCo, Warp, mjlab, and
 RSL-RL versions, then runs 100 finite Warp steps. Start balance training with
 the standard mjlab entry point after Gate D review:

--- a/benchmarks/suites/jump_gate_v1.toml
+++ b/benchmarks/suites/jump_gate_v1.toml
@@ -3,9 +3,6 @@ suite_id = "jump_gate_v1"
 task = "Ascento-Jump-Flat"
 root_seed = 902117
 policy_mode = "deterministic"
-# These capabilities intentionally fail closed on current main. The jump gate
-# must not become authoritative until heading-relative distance, true first-
-# contact impact, and limiting-wheel clearance are canonical signals.
 required_capabilities = [
   "jump_events",
   "command:motion",
@@ -19,7 +16,51 @@ id = "flat_jump"
 kind = "uniform_reset"
 count = 1024
 horizon_s = 8.0
+commands = [
+  { time_s = 0.0, name = "motion", values = [0.0, 0.0, 0.75, 1.0, 0.20, 0.20] },
+  { time_s = 0.01, name = "motion", values = [0.0, 0.0, 0.75, 0.0, 0.20, 0.20] },
+]
 [families.reset]
 roll = [-0.08, 0.08]
 pitch = [-0.08, 0.08]
 yaw = [-3.141592653589793, 3.141592653589793]
+
+[[gates]]
+id = "takeoff_rate"
+family = "flat_jump"
+metric = "jump_takeoff"
+statistic = "success_rate"
+op = ">="
+threshold = 0.90
+
+[[gates]]
+id = "landing_rate"
+family = "flat_jump"
+metric = "jump_landing"
+statistic = "success_rate"
+op = ">="
+threshold = 0.85
+
+[[gates]]
+id = "distance_error_p95"
+family = "flat_jump"
+metric = "jump_distance_abs_error"
+statistic = "p95"
+op = "<="
+threshold = 0.12
+
+[[gates]]
+id = "landing_preimpact_speed_p95"
+family = "flat_jump"
+metric = "landing_preimpact_speed"
+statistic = "p95"
+op = "<="
+threshold = 2.0
+
+[[gates]]
+id = "limiting_wheel_clearance_p05"
+family = "flat_jump"
+metric = "limiting_wheel_clearance"
+statistic = "p05"
+op = ">="
+threshold = 0.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ ascento-evaluate = "ascento_mjlab.evaluation.cli:main"
 ascento-evaluate-checkpoints = "ascento_mjlab.evaluation.checkpoints:main"
 ascento-compare-evaluations = "ascento_mjlab.evaluation.compare:main"
 ascento-replay-eval = "ascento_mjlab.evaluation.replay:main"
+ascento-preflight-evaluator = "ascento_mjlab.evaluation.preflight:main"
 
 [dependency-groups]
 dev = [

--- a/scripts/preflight_long_run.sh
+++ b/scripts/preflight_long_run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTRA="${ASCENTO_COMPUTE_EXTRA:-cu128}"
+PY=(uv run --frozen --extra "$EXTRA")
+
+"${PY[@]}" python -m ascento_mjlab.tools.smoke
+"${PY[@]}" python -m ascento_mjlab.tools.inspect_model
+"${PY[@]}" python -m pytest -q
+
+# Two PPO iterations at the production vector width catch runner/optimizer/GPU
+# failures without pretending that the resulting policy is useful.
+"${PY[@]}" train Ascento-Balance-Flat \
+  --env.scene.num-envs 512 \
+  --agent.max-iterations 2 \
+  --agent.save-interval 1 \
+  --agent.run-name preflight-smoke
+
+if [[ -n "${ASCENTO_BALANCE_CHECKPOINT:-}" \
+   && -n "${ASCENTO_VELOCITY_CHECKPOINT:-}" \
+   && -n "${ASCENTO_RECOVERY_CHECKPOINT:-}" ]]; then
+  "${PY[@]}" ascento-preflight-evaluator \
+    --balance-checkpoint "$ASCENTO_BALANCE_CHECKPOINT" \
+    --velocity-checkpoint "$ASCENTO_VELOCITY_CHECKPOINT" \
+    --recovery-checkpoint "$ASCENTO_RECOVERY_CHECKPOINT" \
+    --device auto
+else
+  echo "Evaluator preflight skipped: set ASCENTO_{BALANCE,VELOCITY,RECOVERY}_CHECKPOINT." >&2
+  exit 3
+fi

--- a/scripts/preflight_long_run.sh
+++ b/scripts/preflight_long_run.sh
@@ -9,12 +9,14 @@ PY=(uv run --frozen --extra "$EXTRA")
 "${PY[@]}" python -m pytest -q
 
 # Two PPO iterations at the production vector width catch runner/optimizer/GPU
-# failures without pretending that the resulting policy is useful.
+# failures without pretending that the resulting policy is useful. TensorBoard
+# keeps this machine-local smoke independent of WandB credentials/network state.
 "${PY[@]}" train Ascento-Balance-Flat \
   --env.scene.num-envs 512 \
   --agent.max-iterations 2 \
   --agent.save-interval 1 \
-  --agent.run-name preflight-smoke
+  --agent.run-name preflight-smoke \
+  --agent.logger tensorboard
 
 if [[ -n "${ASCENTO_BALANCE_CHECKPOINT:-}" \
    && -n "${ASCENTO_VELOCITY_CHECKPOINT:-}" \

--- a/src/ascento_mjlab/evaluation/preflight.py
+++ b/src/ascento_mjlab/evaluation/preflight.py
@@ -1,0 +1,235 @@
+"""Long-run evaluator preflight and determinism checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict, replace
+from pathlib import Path
+
+import torch
+
+from .runner import run_scenarios, task_capabilities, task_step_dt
+from .scenarios import materialize_suite
+from .schema import EpisodeResult, ScenarioSpec, load_suite
+
+
+DEFAULT_SUITES = {
+  "balance": "balance_gate_v1.toml",
+  "velocity": "velocity_gate_v1.toml",
+  "recovery": "recovery_gate_v1.toml",
+}
+
+_ALLOWED_NAN = {
+  "recovery_time_s": "recovered",
+  "recovery_from_start_s": "recovery_success",
+}
+
+
+def _repo_root() -> Path:
+  return Path(__file__).resolve().parents[3]
+
+
+def _suite_path(name: str) -> Path:
+  return _repo_root() / "benchmarks" / "suites" / DEFAULT_SUITES[name]
+
+
+def _assert_results_well_formed(results: list[EpisodeResult]) -> None:
+  if not results:
+    raise RuntimeError("Evaluator returned no episodes")
+  for result in results:
+    if result.termination_reason in {"", "unknown", "done"}:
+      raise RuntimeError(
+        f"Scenario {result.scenario_id} has ambiguous termination reason "
+        f"{result.termination_reason!r}"
+      )
+    if result.episode_steps <= 0:
+      raise RuntimeError(f"Scenario {result.scenario_id} has no valid steps")
+    for name, value in result.metrics.items():
+      if math.isfinite(value):
+        continue
+      gate_metric = _ALLOWED_NAN.get(name)
+      if gate_metric is not None and not bool(result.metrics.get(gate_metric, 0.0)):
+        continue
+      raise RuntimeError(
+        f"Scenario {result.scenario_id} produced non-finite metric {name}={value}"
+      )
+
+
+def _assert_repeatable(
+  first: list[EpisodeResult], second: list[EpisodeResult], *, atol: float = 1.0e-6
+) -> None:
+  if len(first) != len(second):
+    raise RuntimeError("Deterministic repeat changed episode count")
+  for left, right in zip(first, second, strict=True):
+    if (
+      left.scenario_id != right.scenario_id
+      or left.family != right.family
+      or left.success != right.success
+      or left.termination_reason != right.termination_reason
+      or left.episode_steps != right.episode_steps
+    ):
+      raise RuntimeError(
+        f"Deterministic repeat changed discrete result for {left.scenario_id}"
+      )
+    if set(left.metrics) != set(right.metrics):
+      raise RuntimeError(
+        f"Deterministic repeat changed metric schema for {left.scenario_id}"
+      )
+    for name in left.metrics:
+      a, b = left.metrics[name], right.metrics[name]
+      if math.isnan(a) and math.isnan(b):
+        continue
+      if not math.isclose(a, b, rel_tol=0.0, abs_tol=atol):
+        raise RuntimeError(
+          f"Deterministic repeat changed {left.scenario_id}.{name}: {a} vs {b}"
+        )
+
+
+def _mixed_horizon_subset(scenarios: list[ScenarioSpec]) -> list[ScenarioSpec]:
+  if not scenarios:
+    return []
+  source = scenarios[: min(4, len(scenarios))]
+  longest = max(s.horizon_steps for s in source)
+  fractions = (0.20, 0.40, 0.70, 1.0)
+  return [
+    replace(
+      scenario,
+      scenario_id=f"{scenario.scenario_id}__mixed_{index}",
+      horizon_steps=max(5, round(longest * fractions[index])),
+    )
+    for index, scenario in enumerate(source)
+  ]
+
+
+def _assert_mixed_horizon(
+  task: str,
+  checkpoint: Path,
+  scenarios: list[ScenarioSpec],
+  *,
+  device: str,
+) -> dict[str, int]:
+  mixed = _mixed_horizon_subset(scenarios)
+  results, _ = run_scenarios(
+    task,
+    checkpoint,
+    mixed,
+    batch_size=max(1, len(mixed)),
+    device=device,
+    deterministic=True,
+  )
+  _assert_results_well_formed(results)
+  requested = {scenario.scenario_id: scenario.horizon_steps for scenario in mixed}
+  for result in results:
+    horizon = requested[result.scenario_id]
+    if result.episode_steps > horizon:
+      raise RuntimeError(
+        f"Mixed-horizon scenario {result.scenario_id} ran past {horizon} steps"
+      )
+    if result.success and result.episode_steps != horizon:
+      raise RuntimeError(
+        f"Successful mixed-horizon scenario {result.scenario_id} stopped early"
+      )
+  return requested
+
+
+def preflight_suite(
+  suite_name: str,
+  checkpoint: Path,
+  *,
+  device: str,
+  max_scenarios: int,
+  batch_size: int,
+) -> dict:
+  suite = load_suite(_suite_path(suite_name))
+  missing = sorted(set(suite.required_capabilities) - task_capabilities(suite.task))
+  if missing:
+    raise RuntimeError(f"{suite_name} suite missing capabilities: {', '.join(missing)}")
+  scenarios = materialize_suite(suite, task_step_dt(suite.task))
+  scenarios = scenarios[:max_scenarios]
+  if not scenarios:
+    raise RuntimeError(f"{suite_name} suite materialized no scenarios")
+
+  first, first_runtime = run_scenarios(
+    suite.task,
+    checkpoint,
+    scenarios,
+    batch_size=batch_size,
+    device=device,
+    deterministic=True,
+  )
+  _assert_results_well_formed(first)
+  second, second_runtime = run_scenarios(
+    suite.task,
+    checkpoint,
+    scenarios,
+    batch_size=batch_size,
+    device=device,
+    deterministic=True,
+  )
+  _assert_results_well_formed(second)
+  _assert_repeatable(first, second)
+  mixed = _assert_mixed_horizon(
+    suite.task, checkpoint, scenarios, device=device
+  )
+  return {
+    "suite": suite.suite_id,
+    "task": suite.task,
+    "checkpoint": str(checkpoint),
+    "scenario_count": len(scenarios),
+    "repeatable": True,
+    "mixed_horizon": mixed,
+    "first_runtime": first_runtime,
+    "second_runtime": second_runtime,
+    "termination_reasons": sorted({result.termination_reason for result in first}),
+  }
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--balance-checkpoint", type=Path, required=True)
+  parser.add_argument("--velocity-checkpoint", type=Path, required=True)
+  parser.add_argument("--recovery-checkpoint", type=Path, required=True)
+  parser.add_argument("--device", default="auto")
+  parser.add_argument("--max-scenarios", type=int, default=64)
+  parser.add_argument("--batch-size", type=int, default=64)
+  parser.add_argument("--output", type=Path, default=Path("preflight/evaluator.json"))
+  args = parser.parse_args()
+  if args.max_scenarios < 1 or args.batch_size < 1:
+    parser.error("--max-scenarios and --batch-size must be positive")
+
+  checkpoints = {
+    "balance": args.balance_checkpoint,
+    "velocity": args.velocity_checkpoint,
+    "recovery": args.recovery_checkpoint,
+  }
+  for name, checkpoint in checkpoints.items():
+    if not checkpoint.is_file():
+      parser.error(f"{name} checkpoint does not exist: {checkpoint}")
+
+  device = (
+    "cuda:0"
+    if args.device == "auto" and torch.cuda.is_available()
+    else "cpu"
+    if args.device == "auto"
+    else args.device
+  )
+  payload = {
+    name: preflight_suite(
+      name,
+      checkpoint,
+      device=device,
+      max_scenarios=args.max_scenarios,
+      batch_size=args.batch_size,
+    )
+    for name, checkpoint in checkpoints.items()
+  }
+  args.output.parent.mkdir(parents=True, exist_ok=True)
+  args.output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+  print(json.dumps(payload, indent=2, sort_keys=True))
+  print(f"Preflight evidence: {args.output}")
+
+
+if __name__ == "__main__":
+  main()

--- a/src/ascento_mjlab/evaluation/report.py
+++ b/src/ascento_mjlab/evaluation/report.py
@@ -12,7 +12,7 @@ from .schema import EpisodeResult
 from .statistics import summarize_binary, summarize_numeric
 
 
-BINARY_METRICS = {"recovered", "recovery_success"}
+BINARY_METRICS = {"recovered", "recovery_success", "jump_takeoff", "jump_landing"}
 
 
 def summarize_results(
@@ -52,6 +52,8 @@ def select_worst_scenarios(results: list[EpisodeResult], limit: int = 5) -> dict
     "net_displacement": True,
     "effort_rms": True,
     "recovery_time_s": True,
+    "jump_distance_abs_error": True,
+    "landing_preimpact_speed": True,
   }
   output = {"failures": failures}
   for metric, descending in selectors.items():

--- a/src/ascento_mjlab/evaluation/runner.py
+++ b/src/ascento_mjlab/evaluation/runner.py
@@ -15,6 +15,7 @@ from mjlab.tasks.registry import load_env_cfg, load_rl_cfg, load_runner_cls
 from mjlab.utils.lab_api.math import quat_from_euler_xyz, quat_mul
 
 import ascento_mjlab.tasks  # noqa: F401
+from ascento_mjlab.mdp.events import flat_ground_wheel_bottom_heights
 from .policy import RslRlPolicyAdapter
 from .schema import EpisodeResult, ScenarioSpec
 
@@ -45,7 +46,15 @@ def task_capabilities(task: str) -> set[str]:
   if "Recovery" in task:
     capabilities.update({"recovery", "recovery_success"})
   if "Jump" in task:
-    capabilities.update({"jump_events", "command:motion"})
+    capabilities.update(
+      {
+        "jump_events",
+        "command:motion",
+        "jump_distance_tracking",
+        "landing_preimpact",
+        "limiting_wheel_clearance",
+      }
+    )
   return capabilities
 
 
@@ -63,7 +72,7 @@ def task_step_dt(task: str) -> float:
 
 
 def _exact_reset(base_env: ManagerBasedRlEnv, scenarios: list[ScenarioSpec]) -> torch.Tensor:
-  """Overwrite stochastic training resets with resolved scenario states."""
+  """Overwrite stochastic training resets with resolved, support-consistent states."""
   robot = base_env.scene["robot"]
   device = base_env.device
   count = len(scenarios)
@@ -130,18 +139,30 @@ def _exact_reset(base_env: ManagerBasedRlEnv, scenarios: list[ScenarioSpec]) -> 
 
   base_env.sim.forward()
   base_env.sim.sense()
+
+  # A zero scenario Z means "supported flat-ground reset", not "keep the
+  # nominal root height after rotating the robot". Preserve non-zero Z for
+  # scenarios that intentionally request a drop/hover offset.
+  anchor_mask = torch.tensor(
+    [abs(float(scenario.reset.get("z", 0.0))) <= 1.0e-12 for scenario in scenarios],
+    dtype=torch.bool,
+    device=device,
+  )
+  if bool(anchor_mask.any().item()):
+    bottoms = flat_ground_wheel_bottom_heights(base_env, env_ids=env_ids)
+    correction = -bottoms.amin(dim=1)
+    corrected_pose = robot.data.root_link_pose_w[env_ids].clone()
+    corrected_pose[anchor_mask, 2] += correction[anchor_mask]
+    robot.write_root_link_pose_to_sim(corrected_pose, env_ids=env_ids)
+    positions = corrected_pose[:, :3]
+    base_env.sim.forward()
+    base_env.sim.sense()
+
   return positions[:, :2].clone()
 
 
 def _refresh_exact_observation_history(base_env: ManagerBasedRlEnv) -> None:
-  """Seed stateful observation buffers from the exact scenario state only.
-
-  ``env.reset()`` must run first to reset managers, but it also writes a
-  stochastic training reset into history/delay buffers. After `_exact_reset`
-  overwrites that state, clear those buffers and seed them with the resolved
-  deterministic frame so history-dependent policies do not see a hidden random
-  pre-scenario observation.
-  """
+  """Seed stateful observation buffers from the exact scenario state only."""
   env_ids = torch.arange(base_env.num_envs, device=base_env.device, dtype=torch.long)
   base_env.observation_manager.reset(env_ids)
   base_env.obs_buf = base_env.observation_manager.compute(
@@ -150,12 +171,7 @@ def _refresh_exact_observation_history(base_env: ManagerBasedRlEnv) -> None:
 
 
 def _reset_finished_slots(base_env: ManagerBasedRlEnv, policy, finish: torch.Tensor) -> None:
-  """Clear mjlab manual-reset state for completed vector slots.
-
-  mjlab 1.6 requires every done slot to be explicitly reset before the next
-  vector ``step()`` when ``auto_reset=False``. Horizon-complete slots are reset
-  too so all inactive slots have the same benign lifecycle.
-  """
+  """Clear mjlab manual-reset state for completed vector slots."""
   if not bool(finish.any().item()):
     return
   env_ids = finish.nonzero(as_tuple=False).squeeze(-1)
@@ -178,6 +194,16 @@ def _command_values_for_step(
   return updates
 
 
+def _is_explicit_jump_pulse(scenario: ScenarioSpec, step: int) -> bool:
+  return any(
+    point.step == step
+    and point.name == "motion"
+    and len(point.values) >= 4
+    and point.values[3] > 0.5
+    for point in scenario.commands
+  )
+
+
 def _apply_commands(base_env: ManagerBasedRlEnv, scenarios: list[ScenarioSpec], step: int) -> None:
   for name, updates in _command_values_for_step(scenarios, step).items():
     try:
@@ -191,6 +217,12 @@ def _apply_commands(base_env: ManagerBasedRlEnv, scenarios: list[ScenarioSpec], 
           f"Command {name!r} expects {command.shape[1]} values, got {len(values)}"
         )
       command[env_id] = torch.tensor(values, device=command.device, dtype=command.dtype)
+      if (
+        name == "motion"
+        and hasattr(term, "_jump_generation")
+        and _is_explicit_jump_pulse(scenarios[env_id], step)
+      ):
+        term._jump_generation[env_id] += 1
 
 
 def _command_target(
@@ -315,6 +347,7 @@ def _run_batch(
   dev = base_env.device
   is_velocity_task = "Velocity" in task
   is_recovery_task = "Recovery" in task
+  is_jump_task = "Jump" in task
   active = torch.ones(count, dtype=torch.bool, device=dev)
   finished_success = torch.zeros(count, dtype=torch.bool, device=dev)
   episode_steps = torch.zeros(count, dtype=torch.long, device=dev)
@@ -349,6 +382,13 @@ def _run_batch(
   recovery_stable_count = torch.zeros(count, dtype=torch.long, device=dev)
   recovery_success = torch.zeros(count, dtype=torch.bool, device=dev)
   recovery_from_start_s = torch.full((count,), float("nan"), device=dev)
+
+  jump_takeoff_seen = torch.zeros(count, dtype=torch.bool, device=dev)
+  jump_landing_seen = torch.zeros(count, dtype=torch.bool, device=dev)
+  jump_distance_abs_error = torch.ones(count, device=dev)
+  landing_preimpact_speed = torch.full((count,), 10.0, device=dev)
+  limiting_wheel_clearance = torch.zeros(count, device=dev)
+
   prev_xy = initial_xy.clone()
   final_xy_snapshot = initial_xy.clone()
 
@@ -421,8 +461,6 @@ def _run_batch(
       )
       planar_speed = torch.linalg.vector_norm(robot.data.root_link_lin_vel_w[:, :2], dim=1)
       angular_xy = torch.linalg.vector_norm(robot.data.root_link_ang_vel_b[:, :2], dim=1)
-      linear_speed = torch.linalg.vector_norm(robot.data.root_link_lin_vel_b, dim=1)
-      angular_speed = torch.linalg.vector_norm(robot.data.root_link_ang_vel_b, dim=1)
       height = robot.data.root_link_pos_w[:, 2]
       effort = robot.data.actuator_force
       effort_abs = torch.mean(torch.abs(effort), dim=1)
@@ -485,6 +523,32 @@ def _run_batch(
       if height_target is not None:
         sum_height_tracking_sq += torch.square(height - height_target[:, 0]) * weight
       episode_steps += active.long()
+
+      if is_jump_task:
+        state = base_env.ascento_jump_state
+        takeoff_now = state["takeoff"] > 0.5
+        landing_now = state["landing"] > 0.5
+        jump_takeoff_seen |= active & takeoff_now
+        jump_landing_seen |= active & landing_now
+        landing_mask = active & landing_now
+        jump_distance_abs_error = torch.where(
+          landing_mask,
+          torch.abs(state["landing_distance_error"]),
+          jump_distance_abs_error,
+        )
+        landing_preimpact_speed = torch.where(
+          landing_mask,
+          torch.abs(state["landing_preimpact_vz"]),
+          landing_preimpact_speed,
+        )
+        limiting_wheel_clearance = torch.maximum(
+          limiting_wheel_clearance,
+          torch.where(
+            active,
+            state["limiting_wheel_clearance"],
+            torch.zeros_like(limiting_wheel_clearance),
+          ),
+        )
 
       if is_recovery_task:
         from ascento_mjlab.mdp.recovery import RecoveryEnvelope, recovery_condition
@@ -595,6 +659,12 @@ def _run_batch(
     if is_recovery_task:
       arrays["recovery_success"] = recovery_success.float()
       arrays["recovery_from_start_s"] = recovery_from_start_s
+    if is_jump_task:
+      arrays["jump_takeoff"] = jump_takeoff_seen.float()
+      arrays["jump_landing"] = jump_landing_seen.float()
+      arrays["jump_distance_abs_error"] = jump_distance_abs_error
+      arrays["landing_preimpact_speed"] = landing_preimpact_speed
+      arrays["limiting_wheel_clearance"] = limiting_wheel_clearance
     cpu = {key: value.detach().cpu().numpy() for key, value in arrays.items()}
 
     results: list[EpisodeResult] = []

--- a/src/ascento_mjlab/mdp/commands.py
+++ b/src/ascento_mjlab/mdp/commands.py
@@ -68,17 +68,27 @@ class AscentoMotionCommandCfg(CommandTermCfg):
 
 
 class AscentoMotionCommand(CommandTerm):
-  """Six channels: vx, yaw, height, one-shot request, target height, distance."""
+  """Six channels: vx, yaw, height, one-shot request, target height, distance.
+
+  ``jump_generation`` is a monotonically increasing per-environment counter.
+  It lets downstream jump semantics observe every request exactly once even if
+  the visible request pulse has already been cleared by command-manager timing.
+  """
 
   def __init__(self, cfg: AscentoMotionCommandCfg, env) -> None:
     super().__init__(cfg, env)
     self._command = torch.zeros((self.num_envs, 6), device=self.device)
     self._jump_pulse = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
     self._pulse_is_new = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+    self._jump_generation = torch.zeros(self.num_envs, dtype=torch.long, device=self.device)
 
   @property
   def command(self) -> torch.Tensor:
     return self._command
+
+  @property
+  def jump_generation(self) -> torch.Tensor:
+    return self._jump_generation
 
   def _update_metrics(self) -> None:
     return
@@ -94,6 +104,8 @@ class AscentoMotionCommand(CommandTerm):
     self._jump_pulse[env_ids] = samples[:, 5] < self.cfg.jump_probability
     self._command[env_ids, 3] = self._jump_pulse[env_ids].float()
     self._pulse_is_new[env_ids] = True
+    pulse_ids = env_ids[self._jump_pulse[env_ids]]
+    self._jump_generation[pulse_ids] += 1
 
   def _update_command(self, env_ids: torch.Tensor | None) -> None:
     if env_ids is None:

--- a/src/ascento_mjlab/mdp/events.py
+++ b/src/ascento_mjlab/mdp/events.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import torch
 from mjlab.envs.mdp.events import reset_root_state_uniform
 from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply
 
 
 DEFAULT_WHEEL_RADIUS_M = 0.25
+DEFAULT_WHEEL_HALF_WIDTH_M = 0.0025
 
 
 def _resolved_env_ids(env, env_ids: torch.Tensor | slice | None) -> torch.Tensor:
@@ -24,9 +26,17 @@ def flat_ground_wheel_bottom_heights(
   *,
   asset_name: str = "robot",
   wheel_radius_m: float = DEFAULT_WHEEL_RADIUS_M,
+  wheel_half_width_m: float = DEFAULT_WHEEL_HALF_WIDTH_M,
   env_ids: torch.Tensor | slice | None = None,
 ) -> torch.Tensor:
-  """Return [left, right] wheel-bottom heights above the flat support plane."""
+  """Return true outer-tire bottom heights above the flat support plane.
+
+  The wheel collision geom is a cylinder whose axis is the wheel body's local Y
+  axis.  A tilted cylinder does not extend a full radius in world Z, so simply
+  subtracting ``wheel_radius_m`` from the wheel-centre height overestimates its
+  downward extent.  The support extent of a cylinder with axis ``a`` is
+  ``h*|a_z| + r*sqrt(1-a_z^2)``.
+  """
   ids = _resolved_env_ids(env, env_ids)
   asset = env.scene[asset_name]
   try:
@@ -35,10 +45,19 @@ def flat_ground_wheel_bottom_heights(
   except ValueError as exc:
     raise RuntimeError("Expected left_wheel and right_wheel bodies") from exc
 
-  positions = asset.data.body_link_pos_w.index_select(0, ids)
-  wheel_ids = torch.tensor([left_id, right_id], dtype=torch.long, device=positions.device)
-  wheel_positions = positions.index_select(1, wheel_ids)
-  return wheel_positions[..., 2] - float(wheel_radius_m)
+  wheel_ids = torch.tensor(
+    [left_id, right_id], dtype=torch.long, device=asset.data.body_link_pos_w.device
+  )
+  positions = asset.data.body_link_pos_w.index_select(0, ids).index_select(1, wheel_ids)
+  quaternions = asset.data.body_link_quat_w.index_select(0, ids).index_select(1, wheel_ids)
+
+  local_axis = torch.zeros_like(positions)
+  local_axis[..., 1] = 1.0
+  axis_w = quat_apply(quaternions, local_axis)
+  axis_z = axis_w[..., 2].abs().clamp(max=1.0)
+  radial_z = torch.sqrt(torch.clamp(1.0 - axis_z.square(), min=0.0))
+  vertical_extent = float(wheel_half_width_m) * axis_z + float(wheel_radius_m) * radial_z
+  return positions[..., 2] - vertical_extent
 
 
 def reset_root_state_supported(
@@ -48,6 +67,7 @@ def reset_root_state_supported(
   velocity_range: dict[str, tuple[float, float]],
   asset_cfg: SceneEntityCfg,
   wheel_radius_m: float = DEFAULT_WHEEL_RADIUS_M,
+  wheel_half_width_m: float = DEFAULT_WHEEL_HALF_WIDTH_M,
   support_clearance_m: float = 0.0,
 ) -> None:
   """Sample a root reset, then vertically align its lowest wheel with flat ground.
@@ -55,8 +75,8 @@ def reset_root_state_supported(
   The generic mjlab root reset perturbs orientation while leaving the nominal root
   height unchanged. For a wheel-legged robot that can introduce accidental wheel
   penetration or unsupported hovering before the first physics step. This helper
-  preserves the sampled pose/velocity but translates the root in Z so the lowest
-  wheel starts exactly on the flat support plane.
+  preserves the sampled pose/velocity but translates the root in Z so the true
+  lowest point of the outer wheel cylinder starts on the flat support plane.
   """
   reset_root_state_uniform(
     env,
@@ -76,6 +96,7 @@ def reset_root_state_supported(
     env,
     asset_name=asset_cfg.name,
     wheel_radius_m=wheel_radius_m,
+    wheel_half_width_m=wheel_half_width_m,
     env_ids=ids,
   )
   correction = float(support_clearance_m) - bottoms.amin(dim=1)
@@ -87,6 +108,7 @@ def reset_root_state_supported(
 
 
 __all__ = [
+  "DEFAULT_WHEEL_HALF_WIDTH_M",
   "DEFAULT_WHEEL_RADIUS_M",
   "flat_ground_wheel_bottom_heights",
   "reset_root_state_supported",

--- a/src/ascento_mjlab/mdp/events.py
+++ b/src/ascento_mjlab/mdp/events.py
@@ -26,12 +26,19 @@ def flat_ground_wheel_bottom_heights(
   """Return [left, right] wheel-bottom heights above the flat support plane."""
   ids = _resolved_env_ids(env, env_ids)
   asset = env.scene[asset_name]
-  left_ids, _ = asset.find_bodies(r"^left_wheel$")
-  right_ids, _ = asset.find_bodies(r"^right_wheel$")
-  if len(left_ids) != 1 or len(right_ids) != 1:
-    raise RuntimeError("Expected exactly one left_wheel and one right_wheel body")
-  wheel_centres = asset.data.body_link_pos_w[ids][:, [left_ids[0], right_ids[0]], 2]
-  return wheel_centres - float(wheel_radius_m)
+  try:
+    left_id = asset.body_names.index("left_wheel")
+    right_id = asset.body_names.index("right_wheel")
+  except ValueError as exc:
+    raise RuntimeError("Expected left_wheel and right_wheel bodies") from exc
+
+  # Use explicit index_select rather than chained advanced indexing. The latter
+  # can move indexed dimensions in surprising ways and previously returned XYZ
+  # vectors instead of one Z coordinate per wheel.
+  positions = asset.data.body_link_pos_w.index_select(0, ids)
+  wheel_ids = torch.tensor([left_id, right_id], dtype=torch.long, device=positions.device)
+  wheel_positions = positions.index_select(1, wheel_ids)
+  return wheel_positions[..., 2] - float(wheel_radius_m)
 
 
 def reset_root_state_supported(
@@ -46,8 +53,8 @@ def reset_root_state_supported(
   """Sample a root reset, then vertically align its lowest wheel with flat ground.
 
   The generic mjlab root reset perturbs orientation while leaving the nominal root
-  height unchanged.  For a wheel-legged robot that can introduce accidental wheel
-  penetration or unsupported hovering before the first physics step.  This helper
+  height unchanged. For a wheel-legged robot that can introduce accidental wheel
+  penetration or unsupported hovering before the first physics step. This helper
   preserves the sampled pose/velocity but translates the root in Z so the lowest
   wheel starts exactly on the flat support plane.
   """
@@ -72,7 +79,7 @@ def reset_root_state_supported(
     env_ids=ids,
   )
   correction = float(support_clearance_m) - bottoms.amin(dim=1)
-  pose = asset.data.root_link_pose_w[ids].clone()
+  pose = asset.data.root_link_pose_w.index_select(0, ids).clone()
   pose[:, 2] += correction
   asset.write_root_link_pose_to_sim(pose, env_ids=ids)
   env.sim.forward()

--- a/src/ascento_mjlab/mdp/events.py
+++ b/src/ascento_mjlab/mdp/events.py
@@ -11,9 +11,12 @@ DEFAULT_WHEEL_RADIUS_M = 0.25
 
 
 def _resolved_env_ids(env, env_ids: torch.Tensor | slice | None) -> torch.Tensor:
-  if env_ids is None or isinstance(env_ids, slice):
-    return torch.arange(env.num_envs, dtype=torch.long, device=env.device)[env_ids]
-  return env_ids
+  all_ids = torch.arange(env.num_envs, dtype=torch.long, device=env.device)
+  if env_ids is None:
+    return all_ids
+  if isinstance(env_ids, slice):
+    return all_ids[env_ids]
+  return env_ids.reshape(-1).to(dtype=torch.long, device=env.device)
 
 
 def flat_ground_wheel_bottom_heights(
@@ -32,9 +35,6 @@ def flat_ground_wheel_bottom_heights(
   except ValueError as exc:
     raise RuntimeError("Expected left_wheel and right_wheel bodies") from exc
 
-  # Use explicit index_select rather than chained advanced indexing. The latter
-  # can move indexed dimensions in surprising ways and previously returned XYZ
-  # vectors instead of one Z coordinate per wheel.
   positions = asset.data.body_link_pos_w.index_select(0, ids)
   wheel_ids = torch.tensor([left_id, right_id], dtype=torch.long, device=positions.device)
   wheel_positions = positions.index_select(1, wheel_ids)

--- a/src/ascento_mjlab/mdp/events.py
+++ b/src/ascento_mjlab/mdp/events.py
@@ -1,5 +1,87 @@
 """Reset and perturbation presets for Ascento tasks."""
 
-from mjlab.envs.mdp.events import reset_root_state_uniform as reset_root_state_uniform
+from __future__ import annotations
 
-__all__ = ["reset_root_state_uniform"]
+import torch
+from mjlab.envs.mdp.events import reset_root_state_uniform
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+
+
+DEFAULT_WHEEL_RADIUS_M = 0.25
+
+
+def _resolved_env_ids(env, env_ids: torch.Tensor | slice | None) -> torch.Tensor:
+  if env_ids is None or isinstance(env_ids, slice):
+    return torch.arange(env.num_envs, dtype=torch.long, device=env.device)[env_ids]
+  return env_ids
+
+
+def flat_ground_wheel_bottom_heights(
+  env,
+  *,
+  asset_name: str = "robot",
+  wheel_radius_m: float = DEFAULT_WHEEL_RADIUS_M,
+  env_ids: torch.Tensor | slice | None = None,
+) -> torch.Tensor:
+  """Return [left, right] wheel-bottom heights above the flat support plane."""
+  ids = _resolved_env_ids(env, env_ids)
+  asset = env.scene[asset_name]
+  left_ids, _ = asset.find_bodies(r"^left_wheel$")
+  right_ids, _ = asset.find_bodies(r"^right_wheel$")
+  if len(left_ids) != 1 or len(right_ids) != 1:
+    raise RuntimeError("Expected exactly one left_wheel and one right_wheel body")
+  wheel_centres = asset.data.body_link_pos_w[ids][:, [left_ids[0], right_ids[0]], 2]
+  return wheel_centres - float(wheel_radius_m)
+
+
+def reset_root_state_supported(
+  env,
+  env_ids: torch.Tensor | slice | None,
+  pose_range: dict[str, tuple[float, float]],
+  velocity_range: dict[str, tuple[float, float]],
+  asset_cfg: SceneEntityCfg,
+  wheel_radius_m: float = DEFAULT_WHEEL_RADIUS_M,
+  support_clearance_m: float = 0.0,
+) -> None:
+  """Sample a root reset, then vertically align its lowest wheel with flat ground.
+
+  The generic mjlab root reset perturbs orientation while leaving the nominal root
+  height unchanged.  For a wheel-legged robot that can introduce accidental wheel
+  penetration or unsupported hovering before the first physics step.  This helper
+  preserves the sampled pose/velocity but translates the root in Z so the lowest
+  wheel starts exactly on the flat support plane.
+  """
+  reset_root_state_uniform(
+    env,
+    env_ids,
+    pose_range=pose_range,
+    velocity_range=velocity_range,
+    asset_cfg=asset_cfg,
+  )
+  ids = _resolved_env_ids(env, env_ids)
+  if ids.numel() == 0:
+    return
+
+  env.sim.forward()
+  env.sim.sense()
+  asset = env.scene[asset_cfg.name]
+  bottoms = flat_ground_wheel_bottom_heights(
+    env,
+    asset_name=asset_cfg.name,
+    wheel_radius_m=wheel_radius_m,
+    env_ids=ids,
+  )
+  correction = float(support_clearance_m) - bottoms.amin(dim=1)
+  pose = asset.data.root_link_pose_w[ids].clone()
+  pose[:, 2] += correction
+  asset.write_root_link_pose_to_sim(pose, env_ids=ids)
+  env.sim.forward()
+  env.sim.sense()
+
+
+__all__ = [
+  "DEFAULT_WHEEL_RADIUS_M",
+  "flat_ground_wheel_bottom_heights",
+  "reset_root_state_supported",
+  "reset_root_state_uniform",
+]

--- a/src/ascento_mjlab/mdp/jump.py
+++ b/src/ascento_mjlab/mdp/jump.py
@@ -1,7 +1,7 @@
 """Flat-ground jump state semantics and one-attempt phase tracking.
 
 All contact-derived events are synchronized during reward computation from the
-same sensor sample that is returned in the next observation.  A single state
+same sensor sample that is returned in the next observation. A single state
 owner also carries the active jump attempt, heading-relative distance target,
 phase, landing impact sample, and simultaneous two-wheel clearance.
 """
@@ -39,6 +39,7 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
       "phase_time": torch.zeros(env.num_envs, device=env.device),
       "attempt_active": torch.zeros(env.num_envs, dtype=torch.bool, device=env.device),
       "has_taken_off": torch.zeros(env.num_envs, dtype=torch.bool, device=env.device),
+      "last_jump_generation": torch.zeros(env.num_envs, dtype=torch.long, device=env.device),
       "target_distance": torch.zeros(env.num_envs, device=env.device),
       "takeoff_xy": torch.zeros((env.num_envs, 2), device=env.device),
       "takeoff_forward_xy": torch.zeros((env.num_envs, 2), device=env.device),
@@ -59,6 +60,7 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
   state["phase_time"][ids] = 0.0
   state["attempt_active"][ids] = False
   state["has_taken_off"][ids] = False
+  state["last_jump_generation"][ids] = 0
   state["target_distance"][ids] = 0.0
   state["takeoff_xy"][ids] = 0.0
   state["takeoff_forward_xy"][ids] = 0.0
@@ -80,9 +82,9 @@ def _wheel_contacts(env) -> tuple[torch.Tensor, torch.Tensor]:
   )
 
 
-def _motion_command(env) -> torch.Tensor | None:
+def _motion_term(env):
   try:
-    return env.command_manager.get_command("motion")
+    return env.command_manager.get_term("motion")
   except (AttributeError, KeyError):
     return None
 
@@ -129,13 +131,21 @@ def update_jump_state(
   root_vz = robot.data.root_link_lin_vel_w[:, 2]
   root_quat = robot.data.root_link_quat_w
 
-  command = _motion_command(env)
-  request = (
-    command[:, 3] > 0.5
-    if command is not None and command.shape[1] >= 6
-    else torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
-  )
-  new_request = ids & request & ~state["attempt_active"]
+  motion_term = _motion_term(env)
+  command = motion_term.command if motion_term is not None else None
+  if motion_term is not None and hasattr(motion_term, "jump_generation"):
+    generation = motion_term.jump_generation
+    generation_changed = ids & (generation != state["last_jump_generation"])
+    state["last_jump_generation"][generation_changed] = generation[generation_changed]
+    new_request = generation_changed & ~state["attempt_active"]
+  else:
+    request = (
+      command[:, 3] > 0.5
+      if command is not None and command.shape[1] >= 6
+      else torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+    )
+    new_request = ids & request & ~state["attempt_active"]
+
   if bool(new_request.any().item()):
     state["attempt_active"][new_request] = True
     state["has_taken_off"][new_request] = False

--- a/src/ascento_mjlab/mdp/jump.py
+++ b/src/ascento_mjlab/mdp/jump.py
@@ -1,17 +1,32 @@
-"""Flat-ground jump state semantics.
+"""Flat-ground jump state semantics and one-attempt phase tracking.
 
-Jump events are synchronized during reward computation from one contact sample
-instead of through a later step event.  This keeps reward events and the next
-observation on the same policy transition.
+All contact-derived events are synchronized during reward computation from the
+same sensor sample that is returned in the next observation.  A single state
+owner also carries the active jump attempt, heading-relative distance target,
+phase, landing impact sample, and simultaneous two-wheel clearance.
 """
 
 from dataclasses import dataclass
 
 import torch
 
+WHEEL_RADIUS_M = 0.25
+
+PHASE_IDLE = 0
+PHASE_CROUCH = 1
+PHASE_THRUST = 2
+PHASE_FLIGHT = 3
+PHASE_LANDING = 4
+PHASE_RECOVERY = 5
+
+CROUCH_DURATION_S = 0.20
+THRUST_TIMEOUT_S = 1.00
+LANDING_HOLD_S = 0.10
+RECOVERY_HOLD_S = 0.50
+
 
 def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
-  """Initialize the single jump-state owner used by rewards and metrics."""
+  """Initialize the single jump-state owner used by rewards, observations, and metrics."""
   ids = slice(None) if env_ids is None else env_ids
   if not hasattr(env, "ascento_jump_state"):
     env.ascento_jump_state = {
@@ -20,6 +35,16 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
       "takeoff": torch.zeros(env.num_envs, device=env.device),
       "landing": torch.zeros(env.num_envs, device=env.device),
       "air_time": torch.zeros(env.num_envs, device=env.device),
+      "phase": torch.zeros(env.num_envs, dtype=torch.long, device=env.device),
+      "phase_time": torch.zeros(env.num_envs, device=env.device),
+      "attempt_active": torch.zeros(env.num_envs, dtype=torch.bool, device=env.device),
+      "has_taken_off": torch.zeros(env.num_envs, dtype=torch.bool, device=env.device),
+      "target_distance": torch.zeros(env.num_envs, device=env.device),
+      "takeoff_xy": torch.zeros((env.num_envs, 2), device=env.device),
+      "takeoff_forward_xy": torch.zeros((env.num_envs, 2), device=env.device),
+      "remaining_distance": torch.zeros(env.num_envs, device=env.device),
+      "landing_distance_error": torch.ones(env.num_envs, device=env.device),
+      "limiting_wheel_clearance": torch.zeros(env.num_envs, device=env.device),
       "takeoff_height": torch.zeros(env.num_envs, device=env.device),
       "last_airborne_vz": torch.zeros(env.num_envs, device=env.device),
       "landing_preimpact_vz": torch.zeros(env.num_envs, device=env.device),
@@ -30,6 +55,16 @@ def initialize_jump_state(env, env_ids: torch.Tensor | None = None) -> None:
   state["takeoff"][ids] = 0.0
   state["landing"][ids] = 0.0
   state["air_time"][ids] = 0.0
+  state["phase"][ids] = PHASE_IDLE
+  state["phase_time"][ids] = 0.0
+  state["attempt_active"][ids] = False
+  state["has_taken_off"][ids] = False
+  state["target_distance"][ids] = 0.0
+  state["takeoff_xy"][ids] = 0.0
+  state["takeoff_forward_xy"][ids] = 0.0
+  state["remaining_distance"][ids] = 0.0
+  state["landing_distance_error"][ids] = 1.0
+  state["limiting_wheel_clearance"][ids] = 0.0
   state["takeoff_height"][ids] = 0.0
   state["last_airborne_vz"][ids] = 0.0
   state["landing_preimpact_vz"][ids] = 0.0
@@ -45,16 +80,36 @@ def _wheel_contacts(env) -> tuple[torch.Tensor, torch.Tensor]:
   )
 
 
+def _motion_command(env) -> torch.Tensor | None:
+  try:
+    return env.command_manager.get_command("motion")
+  except (AttributeError, KeyError):
+    return None
+
+
+def _forward_xy_from_quat(quat_wxyz: torch.Tensor) -> torch.Tensor:
+  w, x, y, z = quat_wxyz.unbind(dim=1)
+  forward = torch.stack(
+    [1.0 - 2.0 * (y.square() + z.square()), 2.0 * (x * y + w * z)], dim=1
+  )
+  return forward / torch.linalg.vector_norm(forward, dim=1, keepdim=True).clamp(min=1.0e-8)
+
+
+def _wheel_bottom_heights(env) -> torch.Tensor:
+  robot = env.scene["robot"]
+  try:
+    left_id = robot.body_names.index("left_wheel")
+    right_id = robot.body_names.index("right_wheel")
+  except ValueError as exc:
+    raise RuntimeError("Jump metrics require left_wheel and right_wheel bodies") from exc
+  centres = robot.data.body_link_pos_w[:, [left_id, right_id], 2]
+  return centres - WHEEL_RADIUS_M
+
+
 def update_jump_state(
   env, env_ids: torch.Tensor | None = None, dt: float | None = None
 ) -> None:
-  """Synchronize takeoff/landing state from the current wheel-contact sample.
-
-  Takeoff requires both wheels to leave the ground. Landing is the first
-  subsequent contact by either wheel.  ``landing_preimpact_vz`` is sampled from
-  the final prior airborne policy sample, independently from any contact
-  hysteresis or later two-wheel support.
-  """
+  """Synchronize jump events and attempt state from the current policy transition."""
   if not hasattr(env, "ascento_jump_state"):
     initialize_jump_state(env)
   dt = env.step_dt if dt is None else dt
@@ -69,10 +124,47 @@ def update_jump_state(
     ids.zero_()
     ids[env_ids] = True
 
+  robot = env.scene["robot"]
+  root_pos = robot.data.root_link_pos_w
+  root_vz = robot.data.root_link_lin_vel_w[:, 2]
+  root_quat = robot.data.root_link_quat_w
+
+  command = _motion_command(env)
+  request = (
+    command[:, 3] > 0.5
+    if command is not None and command.shape[1] >= 6
+    else torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+  )
+  new_request = ids & request & ~state["attempt_active"]
+  if bool(new_request.any().item()):
+    state["attempt_active"][new_request] = True
+    state["has_taken_off"][new_request] = False
+    state["phase"][new_request] = PHASE_CROUCH
+    state["phase_time"][new_request] = 0.0
+    state["air_time"][new_request] = 0.0
+    state["limiting_wheel_clearance"][new_request] = 0.0
+    state["landing_preimpact_vz"][new_request] = 0.0
+    state["landing_distance_error"][new_request] = 1.0
+    if command is not None:
+      state["target_distance"][new_request] = command[new_request, 5]
+      state["remaining_distance"][new_request] = command[new_request, 5]
+
+  ticking = ids & state["attempt_active"] & ~new_request
+  state["phase_time"][ticking] += dt
+
+  crouch_to_thrust = (
+    ids
+    & state["attempt_active"]
+    & (state["phase"] == PHASE_CROUCH)
+    & (state["phase_time"] >= CROUCH_DURATION_S)
+  )
+  state["phase"][crouch_to_thrust] = PHASE_THRUST
+  state["phase_time"][crouch_to_thrust] = 0.0
+
   previous_supported = state["supported"].clone()
   previous_airborne = state["airborne"].clone()
-  takeoff = ids & previous_supported & airborne
-  landing = ids & previous_airborne & any_contact
+  takeoff = ids & state["attempt_active"] & previous_supported & airborne
+  landing = ids & state["attempt_active"] & previous_airborne & any_contact
 
   state["takeoff"][ids] = 0.0
   state["landing"][ids] = 0.0
@@ -84,25 +176,75 @@ def update_jump_state(
   )
   state["air_time"][takeoff] = dt
 
-  robot = env.scene["robot"]
-  root_height = robot.data.root_link_pos_w[:, 2]
-  root_vz = robot.data.root_link_lin_vel_w[:, 2]
-  state["takeoff_height"][takeoff] = root_height[takeoff]
-  state["landing_preimpact_vz"][landing] = state["last_airborne_vz"][landing]
-  state["last_airborne_vz"][ids & airborne] = root_vz[ids & airborne]
+  if bool(takeoff.any().item()):
+    state["has_taken_off"][takeoff] = True
+    state["phase"][takeoff] = PHASE_FLIGHT
+    state["phase_time"][takeoff] = 0.0
+    state["takeoff_height"][takeoff] = root_pos[takeoff, 2]
+    state["takeoff_xy"][takeoff] = root_pos[takeoff, :2]
+    state["takeoff_forward_xy"][takeoff] = _forward_xy_from_quat(root_quat[takeoff])
+
+  has_reference = ids & state["attempt_active"] & state["has_taken_off"]
+  if bool(has_reference.any().item()):
+    displacement = root_pos[:, :2] - state["takeoff_xy"]
+    forward_distance = torch.sum(displacement * state["takeoff_forward_xy"], dim=1)
+    state["remaining_distance"][has_reference] = (
+      state["target_distance"][has_reference] - forward_distance[has_reference]
+    )
+
+  active_airborne = ids & state["attempt_active"] & airborne
+  if bool(active_airborne.any().item()):
+    limiting_now = _wheel_bottom_heights(env).amin(dim=1)
+    state["limiting_wheel_clearance"][active_airborne] = torch.maximum(
+      state["limiting_wheel_clearance"][active_airborne], limiting_now[active_airborne]
+    )
+    state["last_airborne_vz"][active_airborne] = root_vz[active_airborne]
+
+  if bool(landing.any().item()):
+    state["landing_preimpact_vz"][landing] = state["last_airborne_vz"][landing]
+    state["landing_distance_error"][landing] = -state["remaining_distance"][landing]
+    state["phase"][landing] = PHASE_LANDING
+    state["phase_time"][landing] = 0.0
+
+  landing_to_recovery = (
+    ids
+    & state["attempt_active"]
+    & (state["phase"] == PHASE_LANDING)
+    & (state["phase_time"] >= LANDING_HOLD_S)
+  )
+  state["phase"][landing_to_recovery] = PHASE_RECOVERY
+  state["phase_time"][landing_to_recovery] = 0.0
+
+  recovery_to_idle = (
+    ids
+    & state["attempt_active"]
+    & (state["phase"] == PHASE_RECOVERY)
+    & (state["phase_time"] >= RECOVERY_HOLD_S)
+  )
+  failed_attempt = (
+    ids
+    & state["attempt_active"]
+    & ~state["has_taken_off"]
+    & (state["phase"] == PHASE_THRUST)
+    & (state["phase_time"] >= THRUST_TIMEOUT_S)
+  )
+  finished = recovery_to_idle | failed_attempt
+  state["attempt_active"][finished] = False
+  state["phase"][finished] = PHASE_IDLE
+  state["phase_time"][finished] = 0.0
 
   state["supported"][ids] = supported[ids]
   state["airborne"][ids] = airborne[ids]
 
 
 def sync_jump_state_reward(env) -> torch.Tensor:
-  """Update jump state before jump-dependent rewards, contributing zero reward."""
+  """Update jump state before all jump-dependent rewards, contributing zero reward."""
   update_jump_state(env)
   return torch.zeros(env.num_envs, device=env.device)
 
 
 def phase_features(env) -> torch.Tensor:
-  """Return [airborne, takeoff, landing, air_time] for observations."""
+  """Return contact/event state plus phase and target-relative distance."""
   if not hasattr(env, "ascento_jump_state"):
     initialize_jump_state(env)
   state = env.ascento_jump_state
@@ -112,6 +254,8 @@ def phase_features(env) -> torch.Tensor:
       state["takeoff"],
       state["landing"],
       state["air_time"].clamp(max=2.0),
+      state["phase"].float() / float(PHASE_RECOVERY),
+      state["remaining_distance"].clamp(min=-1.0, max=1.0),
     ],
     dim=1,
   )
@@ -132,4 +276,6 @@ class JumpSemantics:
   takeoff_requires_both_wheels_airborne: bool = True
   landing_is_first_subsequent_wheel_contact: bool = True
   landing_impact_uses_precontact_vertical_speed: bool = True
+  jump_distance_is_takeoff_heading_relative: bool = True
+  clearance_uses_simultaneous_limiting_wheel: bool = True
   terrain_enabled: bool = False

--- a/src/ascento_mjlab/mdp/recovery.py
+++ b/src/ascento_mjlab/mdp/recovery.py
@@ -58,8 +58,8 @@ class RecoverySuccess:
 
   def __init__(self, cfg, env) -> None:
     self.envelope = cfg.params.get("envelope", RecoveryEnvelope())
+    self._step_dt = float(env.step_dt)
     self._stable_steps = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
-    self._required_steps = max(1, round(self.envelope.stable_duration_s / env.step_dt))
 
   def __call__(self, env, envelope: RecoveryEnvelope | None = None) -> torch.Tensor:
     active_envelope = self.envelope if envelope is None else envelope
@@ -67,7 +67,8 @@ class RecoverySuccess:
     self._stable_steps = torch.where(
       stable, self._stable_steps + 1, torch.zeros_like(self._stable_steps)
     )
-    return (self._stable_steps >= self._required_steps).float()
+    required_steps = max(1, round(active_envelope.stable_duration_s / self._step_dt))
+    return (self._stable_steps >= required_steps).float()
 
   def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
     ids = slice(None) if env_ids is None else env_ids

--- a/src/ascento_mjlab/mdp/rewards.py
+++ b/src/ascento_mjlab/mdp/rewards.py
@@ -93,6 +93,70 @@ def track_velocity(
   return torch.exp(-error / (std * std))
 
 
+def _phase_weight(env: ManagerBasedRlEnv, values: tuple[float, ...]) -> torch.Tensor:
+  from .jump import PHASE_RECOVERY
+
+  if len(values) != PHASE_RECOVERY + 1:
+    raise ValueError("phase-weight table must contain idle through recovery")
+  phase = env.ascento_jump_state["phase"].clamp(min=0, max=PHASE_RECOVERY)
+  table = torch.tensor(values, dtype=torch.float32, device=env.device)
+  return table[phase]
+
+
+def jump_nominal_height_tracking(
+  env: ManagerBasedRlEnv,
+  target: float = 0.75,
+  std: float = 0.08,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  """Use nominal-height pressure only where it does not fight the jump motion."""
+  weight = _phase_weight(env, (1.0, 0.05, 0.0, 0.0, 0.20, 0.70))
+  return height_tracking(env, target=target, std=std, asset_cfg=asset_cfg) * weight
+
+
+def jump_angular_rate_penalty(
+  env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
+) -> torch.Tensor:
+  weight = _phase_weight(env, (1.0, 0.8, 0.5, 0.7, 1.0, 1.0))
+  return angular_rate_penalty(env, asset_cfg=asset_cfg) * weight
+
+
+def jump_planar_speed_penalty(
+  env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG
+) -> torch.Tensor:
+  weight = _phase_weight(env, (1.0, 0.5, 0.2, 0.0, 0.3, 1.0))
+  return planar_speed_penalty(env, asset_cfg=asset_cfg) * weight
+
+
+def jump_crouch(
+  env: ManagerBasedRlEnv,
+  target_height: float = 0.64,
+  std: float = 0.05,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  """Reward an actual lower body pose, not unsigned joint displacement."""
+  from .jump import PHASE_CROUCH
+
+  asset: Entity = env.scene[asset_cfg.name]
+  error = asset.data.root_link_pos_w[:, 2] - target_height
+  score = torch.exp(-torch.square(error) / (std * std))
+  return score * (env.ascento_jump_state["phase"] == PHASE_CROUCH).float()
+
+
+def jump_thrust(
+  env: ManagerBasedRlEnv,
+  target_vz: float = 1.2,
+  std: float = 0.7,
+  asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> torch.Tensor:
+  from .jump import PHASE_THRUST
+
+  asset: Entity = env.scene[asset_cfg.name]
+  error = asset.data.root_link_lin_vel_w[:, 2] - target_vz
+  score = torch.exp(-torch.square(error) / (std * std))
+  return score * (env.ascento_jump_state["phase"] == PHASE_THRUST).float()
+
+
 def jump_takeoff(env: ManagerBasedRlEnv) -> torch.Tensor:
   from .jump import takeoff_bonus
 
@@ -103,6 +167,20 @@ def jump_landing(env: ManagerBasedRlEnv) -> torch.Tensor:
   from .jump import landing_bonus
 
   return landing_bonus(env)
+
+
+def jump_distance_tracking(env: ManagerBasedRlEnv, std: float = 0.08) -> torch.Tensor:
+  """Score heading-relative landing displacement against the requested distance."""
+  state = env.ascento_jump_state
+  score = torch.exp(-torch.square(state["landing_distance_error"]) / (std * std))
+  return score * state["landing"]
+
+
+def jump_landing_softness(env: ManagerBasedRlEnv, std: float = 1.0) -> torch.Tensor:
+  """Reward low pre-contact vertical speed without using post-contact deceleration."""
+  state = env.ascento_jump_state
+  score = torch.exp(-torch.square(state["landing_preimpact_vz"]) / (std * std))
+  return score * state["landing"]
 
 
 def airborne_height_progress(

--- a/src/ascento_mjlab/tasks/balance/env_cfg.py
+++ b/src/ascento_mjlab/tasks/balance/env_cfg.py
@@ -127,8 +127,6 @@ def _actions() -> dict[str, ActionTermCfg]:
       entity_name="robot",
       actuator_names=JOINT_NAMES,
       scale=effort_limit,
-      # JointEffortActionCfg clips after scale/offset. The physical target
-      # therefore needs the physical Nm clamp, not the normalized policy clamp.
       clip={".*": (-effort_limit, effort_limit)},
       preserve_order=True,
     )
@@ -151,7 +149,7 @@ def ascento_balance_env_cfg(
         func=mdp.reset_scene_to_default, mode="reset"
       ),
       "reset_supported_pose": EventTermCfg(
-        func=ascento_mdp.events.reset_root_state_uniform,
+        func=ascento_mdp.events.reset_root_state_supported,
         mode="reset",
         params={
           "pose_range": {

--- a/src/ascento_mjlab/tasks/jump/env_cfg.py
+++ b/src/ascento_mjlab/tasks/jump/env_cfg.py
@@ -1,7 +1,7 @@
-"""Flat-ground jump specialist configuration placeholder.
+"""Flat-ground jump specialist configuration.
 
-Terrain is intentionally disabled here. This task is not expanded until
-takeoff, flight, landing, and post-landing recovery are sound on a plane.
+Terrain remains intentionally disabled until flat-ground takeoff, flight,
+landing, distance tracking, and recovery are all quantitatively sound.
 """
 
 from mjlab.managers.event_manager import EventTermCfg
@@ -9,7 +9,7 @@ from mjlab.managers.observation_manager import ObservationTermCfg
 from mjlab.managers.reward_manager import RewardTermCfg
 
 from ascento_mjlab import mdp as ascento_mdp
-from ascento_mjlab.tasks.balance.env_cfg import ascento_balance_env_cfg
+from ascento_mjlab.tasks.balance.env_cfg import ROBOT_CFG, ascento_balance_env_cfg
 
 
 def ascento_jump_env_cfg(play: bool = False, num_envs: int = 512):
@@ -45,19 +45,55 @@ def ascento_jump_env_cfg(play: bool = False, num_envs: int = 512):
     mode="reset",
   )
 
-  # Reward computation happens before mjlab's step events. Synchronize the
-  # contact-derived jump state here so takeoff/landing rewards correspond to
-  # the same transition that produced the returned contact observation.
-  cfg.rewards["jump_state_sync"] = RewardTermCfg(
-    func=ascento_mdp.jump.sync_jump_state_reward,
+  # Synchronization must be the first reward term. Phase-dependent inherited
+  # rewards otherwise see the previous contact sample/phase on a transition.
+  base_rewards = dict(cfg.rewards)
+  base_rewards["height"] = RewardTermCfg(
+    func=ascento_mdp.rewards.jump_nominal_height_tracking,
     weight=1.0,
+    params={"target": 0.75, "std": 0.08, "asset_cfg": ROBOT_CFG},
   )
-  cfg.rewards["takeoff"] = RewardTermCfg(func=ascento_mdp.rewards.jump_takeoff, weight=2.0)
-  cfg.rewards["landing"] = RewardTermCfg(func=ascento_mdp.rewards.jump_landing, weight=3.0)
-  cfg.rewards["height_progress"] = RewardTermCfg(
-    func=ascento_mdp.rewards.airborne_height_progress,
-    weight=0.5,
-    params={"command_name": "motion"},
+  base_rewards["angular_rate"] = RewardTermCfg(
+    func=ascento_mdp.rewards.jump_angular_rate_penalty,
+    weight=-0.04,
+    params={"asset_cfg": ROBOT_CFG},
   )
+  base_rewards["planar_speed"] = RewardTermCfg(
+    func=ascento_mdp.rewards.jump_planar_speed_penalty,
+    weight=-0.2,
+    params={"asset_cfg": ROBOT_CFG},
+  )
+  cfg.rewards = {
+    "jump_state_sync": RewardTermCfg(
+      func=ascento_mdp.jump.sync_jump_state_reward,
+      weight=1.0,
+    ),
+    **base_rewards,
+    "crouch": RewardTermCfg(
+      func=ascento_mdp.rewards.jump_crouch,
+      weight=0.8,
+      params={"asset_cfg": ROBOT_CFG},
+    ),
+    "thrust": RewardTermCfg(
+      func=ascento_mdp.rewards.jump_thrust,
+      weight=1.2,
+      params={"asset_cfg": ROBOT_CFG},
+    ),
+    "takeoff": RewardTermCfg(func=ascento_mdp.rewards.jump_takeoff, weight=2.0),
+    "landing": RewardTermCfg(func=ascento_mdp.rewards.jump_landing, weight=2.0),
+    "landing_softness": RewardTermCfg(
+      func=ascento_mdp.rewards.jump_landing_softness,
+      weight=1.0,
+    ),
+    "distance_tracking": RewardTermCfg(
+      func=ascento_mdp.rewards.jump_distance_tracking,
+      weight=3.0,
+    ),
+    "height_progress": RewardTermCfg(
+      func=ascento_mdp.rewards.airborne_height_progress,
+      weight=0.5,
+      params={"command_name": "motion"},
+    ),
+  }
   cfg.episode_length_s = 8.0 if not play else 10000.0
   return cfg

--- a/tests_mjlab/evaluation/test_preflight.py
+++ b/tests_mjlab/evaluation/test_preflight.py
@@ -1,0 +1,59 @@
+from dataclasses import replace
+
+import pytest
+
+from ascento_mjlab.evaluation.preflight import (
+  _assert_repeatable,
+  _assert_results_well_formed,
+  _mixed_horizon_subset,
+)
+from ascento_mjlab.evaluation.schema import EpisodeResult, ScenarioSpec
+
+
+def _result(**overrides):
+  result = EpisodeResult(
+    scenario_id="scenario-0",
+    family="family",
+    success=True,
+    termination_reason="horizon",
+    episode_steps=20,
+    metrics={"tilt_rms": 0.1, "recovery_success": 0.0, "recovery_from_start_s": float("nan")},
+  )
+  for key, value in overrides.items():
+    setattr(result, key, value)
+  return result
+
+
+def test_well_formed_allows_only_inapplicable_recovery_nan():
+  _assert_results_well_formed([_result()])
+
+  bad = _result()
+  bad.metrics["tilt_rms"] = float("nan")
+  with pytest.raises(RuntimeError, match="non-finite metric tilt_rms"):
+    _assert_results_well_formed([bad])
+
+
+def test_repeatability_compares_discrete_and_numeric_results():
+  first = _result()
+  second = _result()
+  _assert_repeatable([first], [second])
+
+  changed = _result()
+  changed.metrics["tilt_rms"] += 1.0e-3
+  with pytest.raises(RuntimeError, match="Deterministic repeat changed"):
+    _assert_repeatable([first], [changed])
+
+
+def test_mixed_horizon_subset_contains_distinct_lengths():
+  base = ScenarioSpec(
+    scenario_id="s",
+    family="f",
+    task="Ascento-Balance-Flat",
+    horizon_steps=100,
+    reset={},
+  )
+  scenarios = [replace(base, scenario_id=f"s-{index}") for index in range(4)]
+  mixed = _mixed_horizon_subset(scenarios)
+
+  assert [scenario.horizon_steps for scenario in mixed] == [20, 40, 70, 100]
+  assert len({scenario.scenario_id for scenario in mixed}) == 4

--- a/tests_mjlab/test_jump_alignment_integration.py
+++ b/tests_mjlab/test_jump_alignment_integration.py
@@ -30,12 +30,21 @@ def _set_root_pose(env, *, z: float, roll: float = 0.0) -> None:
   pose[0, 3:7] = quat_from_euler_xyz(
     torch.tensor([roll], device=env.device), zero, zero
   )[0]
-  robot.write_root_link_pose_to_sim(pose, env_ids=torch.tensor([0], device=env.device))
+  env_id = torch.tensor([0], device=env.device)
+  robot.write_root_link_pose_to_sim(pose, env_ids=env_id)
   robot.write_root_link_velocity_to_sim(
-    torch.zeros((1, 6), device=env.device), env_ids=torch.tensor([0], device=env.device)
+    torch.zeros((1, 6), device=env.device), env_ids=env_id
   )
   env.sim.forward()
   env.sim.sense()
+
+
+def _find_static_pose_with_contact_count(env, *, roll: float, count: int) -> float:
+  for z in torch.linspace(0.90, 0.45, 181).tolist():
+    _set_root_pose(env, z=float(z), roll=roll)
+    if sum(_contacts(env)) == count:
+      return float(z)
+  raise AssertionError(f"could not construct a static pose with {count} wheel contacts")
 
 
 def _transition(env):
@@ -59,10 +68,21 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
   cfg = load_env_cfg("Ascento-Jump-Flat", play=True)
   cfg.scene.num_envs = 1
   cfg.auto_reset = False
+  # Eliminate stochastic command requests; this test injects one exact request.
+  cfg.commands["motion"].jump_probability = 0.0
   env = ManagerBasedRlEnv(cfg, device="cpu")
   try:
     env.reset()
-    assert _contacts(env) == (True, True)
+
+    # Establish a genuinely supported state through a real policy transition.
+    # Geometric tangency alone need not set a contact sensor until physics runs.
+    supported_z = _find_static_pose_with_contact_count(env, roll=0.0, count=2)
+    _set_root_pose(env, z=supported_z, roll=0.0)
+    supported_row = _transition(env)
+    assert supported_row["contacts"] == (True, True)
+    assert supported_row["airborne"] is False
+    assert supported_row["takeoff"] == 0.0
+    assert supported_row["landing"] == 0.0
 
     # Force exactly one new jump request without relying on the visible pulse
     # surviving command-manager update order.
@@ -72,7 +92,8 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
     motion._jump_generation[0] += 1
 
     # Lift the actual simulated robot clear of the plane, then take one real
-    # ManagerBasedRlEnv policy transition.
+    # ManagerBasedRlEnv policy transition. Contact observation, jump state and
+    # reward pulse must describe this same transition.
     _set_root_pose(env, z=1.05, roll=0.0)
     takeoff_row = _transition(env)
 
@@ -83,18 +104,10 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
     assert takeoff_row["rewards"]["takeoff"] > 0.0
     assert takeoff_row["rewards"]["landing"] == 0.0
 
-    # Find a static tilted pose with exactly one wheel contacting the plane.
-    # Sensor probing does not update the jump state; the subsequent env.step is
-    # therefore the first policy transition after the airborne sample.
-    candidate = None
-    for z in torch.linspace(0.80, 0.50, 61).tolist():
-      _set_root_pose(env, z=float(z), roll=0.30)
-      if sum(_contacts(env)) == 1:
-        candidate = float(z)
-        break
-    assert candidate is not None, "could not construct a one-wheel first-contact pose"
-
-    _set_root_pose(env, z=candidate, roll=0.30)
+    # Probe for a one-wheel first-contact pose without updating jump state;
+    # only the subsequent env.step is allowed to create the landing event.
+    one_wheel_z = _find_static_pose_with_contact_count(env, roll=0.30, count=1)
+    _set_root_pose(env, z=one_wheel_z, roll=0.30)
     landing_row = _transition(env)
 
     assert sum(landing_row["contacts"]) == 1

--- a/tests_mjlab/test_jump_alignment_integration.py
+++ b/tests_mjlab/test_jump_alignment_integration.py
@@ -1,0 +1,106 @@
+import torch
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.tasks.registry import load_env_cfg
+from mjlab.utils.lab_api.math import quat_from_euler_xyz
+
+import ascento_mjlab.tasks  # noqa: F401
+
+
+def _contacts(env):
+  values = []
+  for name in ("left_wheel_contact", "right_wheel_contact"):
+    found = env.scene[name].data.found
+    assert found is not None
+    values.append(bool(found[0].flatten().any().item()))
+  return tuple(values)
+
+
+def _reward_terms(env):
+  return {
+    name: float(values[0])
+    for name, values in env.reward_manager.get_active_iterable_terms(0)
+  }
+
+
+def _set_root_pose(env, *, z: float, roll: float = 0.0) -> None:
+  robot = env.scene["robot"]
+  pose = robot.data.root_link_pose_w[:1].clone()
+  pose[0, 2] = z
+  zero = torch.zeros(1, device=env.device)
+  pose[0, 3:7] = quat_from_euler_xyz(
+    torch.tensor([roll], device=env.device), zero, zero
+  )[0]
+  robot.write_root_link_pose_to_sim(pose, env_ids=torch.tensor([0], device=env.device))
+  robot.write_root_link_velocity_to_sim(
+    torch.zeros((1, 6), device=env.device), env_ids=torch.tensor([0], device=env.device)
+  )
+  env.sim.forward()
+  env.sim.sense()
+
+
+def _transition(env):
+  obs, reward, terminated, truncated, _ = env.step(torch.zeros((1, 6), device=env.device))
+  state = env.ascento_jump_state
+  row = {
+    "contacts": _contacts(env),
+    "airborne": bool(state["airborne"][0].item()),
+    "takeoff": float(state["takeoff"][0].item()),
+    "landing": float(state["landing"][0].item()),
+    "rewards": _reward_terms(env),
+    "terminated": bool(terminated[0].item()),
+    "truncated": bool(truncated[0].item()),
+  }
+  assert torch.isfinite(obs["actor"]).all()
+  assert torch.isfinite(reward).all()
+  return row
+
+
+def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
+  cfg = load_env_cfg("Ascento-Jump-Flat", play=True)
+  cfg.scene.num_envs = 1
+  cfg.auto_reset = False
+  env = ManagerBasedRlEnv(cfg, device="cpu")
+  try:
+    env.reset()
+    assert _contacts(env) == (True, True)
+
+    # Force exactly one new jump request without relying on the visible pulse
+    # surviving command-manager update order.
+    motion = env.command_manager.get_term("motion")
+    motion._command[0] = torch.tensor([0.0, 0.0, 0.75, 1.0, 0.20, 0.20])
+    motion._jump_pulse[0] = True
+    motion._jump_generation[0] += 1
+
+    # Lift the actual simulated robot clear of the plane, then take one real
+    # ManagerBasedRlEnv policy transition.
+    _set_root_pose(env, z=1.05, roll=0.0)
+    takeoff_row = _transition(env)
+
+    assert takeoff_row["contacts"] == (False, False)
+    assert takeoff_row["airborne"] is True
+    assert takeoff_row["takeoff"] == 1.0
+    assert takeoff_row["landing"] == 0.0
+    assert takeoff_row["rewards"]["takeoff"] > 0.0
+    assert takeoff_row["rewards"]["landing"] == 0.0
+
+    # Find a static tilted pose with exactly one wheel contacting the plane.
+    # Sensor probing does not update the jump state; the subsequent env.step is
+    # therefore the first policy transition after the airborne sample.
+    candidate = None
+    for z in torch.linspace(0.80, 0.50, 61).tolist():
+      _set_root_pose(env, z=float(z), roll=0.30)
+      if sum(_contacts(env)) == 1:
+        candidate = float(z)
+        break
+    assert candidate is not None, "could not construct a one-wheel first-contact pose"
+
+    _set_root_pose(env, z=candidate, roll=0.30)
+    landing_row = _transition(env)
+
+    assert sum(landing_row["contacts"]) == 1
+    assert landing_row["airborne"] is False
+    assert landing_row["takeoff"] == 0.0
+    assert landing_row["landing"] == 1.0
+    assert landing_row["rewards"]["landing"] > 0.0
+  finally:
+    env.close()

--- a/tests_mjlab/test_jump_alignment_integration.py
+++ b/tests_mjlab/test_jump_alignment_integration.py
@@ -4,6 +4,7 @@ from mjlab.tasks.registry import load_env_cfg
 from mjlab.utils.lab_api.math import quat_from_euler_xyz
 
 import ascento_mjlab.tasks  # noqa: F401
+from ascento_mjlab.mdp.events import flat_ground_wheel_bottom_heights
 
 
 def _contacts(env):
@@ -30,7 +31,7 @@ def _set_root_pose(env, *, z: float, roll: float = 0.0) -> None:
   pose[0, 3:7] = quat_from_euler_xyz(
     torch.tensor([roll], device=env.device), zero, zero
   )[0]
-  env_id = torch.tensor([0], device=env.device)
+  env_id = torch.tensor([0], dtype=torch.long, device=env.device)
   robot.write_root_link_pose_to_sim(pose, env_ids=env_id)
   robot.write_root_link_velocity_to_sim(
     torch.zeros((1, 6), device=env.device), env_ids=env_id
@@ -39,16 +40,29 @@ def _set_root_pose(env, *, z: float, roll: float = 0.0) -> None:
   env.sim.sense()
 
 
-def _find_static_pose_with_contact_count(env, *, roll: float, count: int) -> float:
-  for z in torch.linspace(0.90, 0.45, 181).tolist():
-    _set_root_pose(env, z=float(z), roll=roll)
-    if sum(_contacts(env)) == count:
-      return float(z)
-  raise AssertionError(f"could not construct a static pose with {count} wheel contacts")
+def _place_lowest_wheel_on_support(
+  env, *, roll: float, penetration_m: float = 0.002
+) -> None:
+  """Pose the robot geometrically; contact truth is read only after env.step()."""
+  _set_root_pose(env, z=1.0, roll=roll)
+  bottoms = flat_ground_wheel_bottom_heights(env, env_ids=torch.tensor([0], device=env.device))
+  correction = -float(penetration_m) - float(bottoms.amin().item())
+  robot = env.scene["robot"]
+  pose = robot.data.root_link_pose_w[:1].clone()
+  pose[0, 2] += correction
+  env_id = torch.tensor([0], dtype=torch.long, device=env.device)
+  robot.write_root_link_pose_to_sim(pose, env_ids=env_id)
+  robot.write_root_link_velocity_to_sim(
+    torch.zeros((1, 6), device=env.device), env_ids=env_id
+  )
+  env.sim.forward()
+  env.sim.sense()
 
 
 def _transition(env):
-  obs, reward, terminated, truncated, _ = env.step(torch.zeros((1, 6), device=env.device))
+  obs, reward, terminated, truncated, _ = env.step(
+    torch.zeros((1, 6), device=env.device)
+  )
   state = env.ascento_jump_state
   row = {
     "contacts": _contacts(env),
@@ -74,10 +88,10 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
   try:
     env.reset()
 
-    # Establish a genuinely supported state through a real policy transition.
-    # Geometric tangency alone need not set a contact sensor until physics runs.
-    supported_z = _find_static_pose_with_contact_count(env, roll=0.0, count=2)
-    _set_root_pose(env, z=supported_z, roll=0.0)
+    # Establish support through an actual policy transition. sim.forward()/sense()
+    # is used only to place geometry; contact sensors are never asserted until
+    # ManagerBasedRlEnv.step() has returned.
+    _place_lowest_wheel_on_support(env, roll=0.0)
     supported_row = _transition(env)
     assert supported_row["contacts"] == (True, True)
     assert supported_row["airborne"] is False
@@ -91,9 +105,8 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
     motion._jump_pulse[0] = True
     motion._jump_generation[0] += 1
 
-    # Lift the actual simulated robot clear of the plane, then take one real
-    # ManagerBasedRlEnv policy transition. Contact observation, jump state and
-    # reward pulse must describe this same transition.
+    # The returned transition must simultaneously report no contacts, airborne,
+    # the takeoff event, and the takeoff reward pulse.
     _set_root_pose(env, z=1.05, roll=0.0)
     takeoff_row = _transition(env)
 
@@ -104,10 +117,10 @@ def test_real_jump_rollout_aligns_contacts_state_and_reward_pulses():
     assert takeoff_row["rewards"]["takeoff"] > 0.0
     assert takeoff_row["rewards"]["landing"] == 0.0
 
-    # Probe for a one-wheel first-contact pose without updating jump state;
-    # only the subsequent env.step is allowed to create the landing event.
-    one_wheel_z = _find_static_pose_with_contact_count(env, roll=0.30, count=1)
-    _set_root_pose(env, z=one_wheel_z, roll=0.30)
+    # Tilt the robot and place only its lower wheel into the support plane. This
+    # is the first post-takeoff contact transition; it must therefore produce
+    # landing on the same returned transition, even though the other wheel is free.
+    _place_lowest_wheel_on_support(env, roll=0.30)
     landing_row = _transition(env)
 
     assert sum(landing_row["contacts"]) == 1

--- a/tests_mjlab/test_jump_semantics.py
+++ b/tests_mjlab/test_jump_semantics.py
@@ -6,9 +6,27 @@ import torch
 from ascento_mjlab.mdp.commands import AscentoMotionCommandCfg
 from ascento_mjlab.mdp.jump import (
   JumpSemantics,
+  PHASE_CROUCH,
+  PHASE_FLIGHT,
   initialize_jump_state,
   update_jump_state,
 )
+
+
+class _MotionTerm:
+  def __init__(self):
+    self.command = torch.zeros((1, 6))
+    self.jump_generation = torch.zeros(1, dtype=torch.long)
+
+
+class _CommandManager:
+  def __init__(self, term):
+    self.term = term
+
+  def get_term(self, name):
+    if name != "motion":
+      raise KeyError(name)
+    return self.term
 
 
 def _jump_env(*, step_dt: float = 0.01):
@@ -17,19 +35,32 @@ def _jump_env(*, step_dt: float = 0.01):
   robot_data = SimpleNamespace(
     root_link_pos_w=torch.tensor([[0.0, 0.0, 0.75]]),
     root_link_lin_vel_w=torch.zeros((1, 3)),
+    root_link_quat_w=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+    body_link_pos_w=torch.tensor([[[0.0, 0.1, 0.25], [0.0, -0.1, 0.25]]]),
   )
+  robot = SimpleNamespace(
+    data=robot_data,
+    body_names=("left_wheel", "right_wheel"),
+  )
+  motion = _MotionTerm()
   env = SimpleNamespace(
     num_envs=1,
     device="cpu",
     step_dt=step_dt,
+    command_manager=_CommandManager(motion),
     scene={
       "left_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=left)),
       "right_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=right)),
-      "robot": SimpleNamespace(data=robot_data),
+      "robot": robot,
     },
   )
   initialize_jump_state(env)
-  return env, left, right, robot_data
+  return env, left, right, robot_data, motion
+
+
+def _request_jump(motion, *, distance: float = 0.2):
+  motion.command[0] = torch.tensor([0.0, 0.0, 0.75, 1.0, 0.2, distance])
+  motion.jump_generation[0] += 1
 
 
 def test_jump_semantics_keeps_terrain_behind_flat_ground_gate():
@@ -37,6 +68,8 @@ def test_jump_semantics_keeps_terrain_behind_flat_ground_gate():
   assert semantics.takeoff_requires_both_wheels_airborne
   assert semantics.landing_is_first_subsequent_wheel_contact
   assert semantics.landing_impact_uses_precontact_vertical_speed
+  assert semantics.jump_distance_is_takeoff_heading_relative
+  assert semantics.clearance_uses_simultaneous_limiting_wheel
   assert semantics.terrain_enabled is False
 
 
@@ -59,18 +92,34 @@ def test_motion_command_one_shot_is_explicitly_documented():
 
 
 def test_jump_state_defaults_to_active_environment_step_dt():
-  env, left, right, _ = _jump_env(step_dt=0.037)
+  env, left, right, _, motion = _jump_env(step_dt=0.037)
+  _request_jump(motion)
+  update_jump_state(env)
+  assert env.ascento_jump_state["phase"].item() == PHASE_CROUCH
+
   left.zero_()
   right.zero_()
-
   update_jump_state(env)
 
   assert env.ascento_jump_state["air_time"].item() == pytest.approx(0.037)
   assert env.ascento_jump_state["takeoff"].item() == pytest.approx(1.0)
+  assert env.ascento_jump_state["phase"].item() == PHASE_FLIGHT
+
+
+def test_unrequested_contact_loss_is_not_a_takeoff_event():
+  env, left, right, _, _ = _jump_env()
+  left.zero_()
+  right.zero_()
+  update_jump_state(env)
+
+  assert env.ascento_jump_state["airborne"].item()
+  assert env.ascento_jump_state["takeoff"].item() == 0.0
 
 
 def test_landing_is_first_subsequent_contact_even_with_one_wheel():
-  env, left, right, _ = _jump_env()
+  env, left, right, _, motion = _jump_env()
+  _request_jump(motion)
+  update_jump_state(env)
   left.zero_()
   right.zero_()
   update_jump_state(env)
@@ -84,7 +133,9 @@ def test_landing_is_first_subsequent_contact_even_with_one_wheel():
 
 
 def test_landing_impact_uses_last_airborne_velocity_not_post_contact_velocity():
-  env, left, right, robot = _jump_env()
+  env, left, right, robot, motion = _jump_env()
+  _request_jump(motion)
+  update_jump_state(env)
   left.zero_()
   right.zero_()
   robot.root_link_lin_vel_w[0, 2] = 1.2
@@ -100,3 +151,32 @@ def test_landing_impact_uses_last_airborne_velocity_not_post_contact_velocity():
 
   assert env.ascento_jump_state["landing"].item() == pytest.approx(1.0)
   assert env.ascento_jump_state["landing_preimpact_vz"].item() == pytest.approx(-3.4)
+
+
+def test_distance_is_measured_in_takeoff_heading_frame():
+  env, left, right, robot, motion = _jump_env()
+  _request_jump(motion, distance=0.30)
+  update_jump_state(env)
+  left.zero_()
+  right.zero_()
+  update_jump_state(env)
+
+  robot.root_link_pos_w[0, 0] = 0.24
+  update_jump_state(env)
+  left.fill_(True)
+  update_jump_state(env)
+
+  assert env.ascento_jump_state["landing_distance_error"].item() == pytest.approx(-0.06)
+
+
+def test_clearance_uses_lower_wheel_at_each_airborne_sample():
+  env, left, right, robot, motion = _jump_env()
+  _request_jump(motion)
+  update_jump_state(env)
+  left.zero_()
+  right.zero_()
+  robot.body_link_pos_w[0, 0, 2] = 0.45
+  robot.body_link_pos_w[0, 1, 2] = 0.30
+  update_jump_state(env)
+
+  assert env.ascento_jump_state["limiting_wheel_clearance"].item() == pytest.approx(0.05)

--- a/tests_mjlab/test_recovery_semantics.py
+++ b/tests_mjlab/test_recovery_semantics.py
@@ -1,0 +1,87 @@
+from math import cos, sin
+from types import SimpleNamespace
+
+import torch
+
+from ascento_mjlab.mdp.recovery import RecoveryEnvelope, RecoverySuccess, recovery_condition
+
+
+def _recovery_env(*, step_dt: float = 0.01):
+  left = torch.ones((1, 1), dtype=torch.bool)
+  right = torch.ones((1, 1), dtype=torch.bool)
+  robot_data = SimpleNamespace(
+    projected_gravity_b=torch.tensor([[0.0, 0.0, -1.0]]),
+    root_link_pos_w=torch.tensor([[0.0, 0.0, 0.75]]),
+    root_link_lin_vel_b=torch.zeros((1, 3)),
+    root_link_ang_vel_b=torch.zeros((1, 3)),
+  )
+  env = SimpleNamespace(
+    num_envs=1,
+    device="cpu",
+    step_dt=step_dt,
+    scene={
+      "robot": SimpleNamespace(data=robot_data),
+      "left_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=left)),
+      "right_wheel_contact": SimpleNamespace(data=SimpleNamespace(found=right)),
+    },
+  )
+  return env, robot_data, left, right
+
+
+def _metric(env, envelope: RecoveryEnvelope = RecoveryEnvelope()):
+  cfg = SimpleNamespace(params={"envelope": envelope})
+  return RecoverySuccess(cfg, env)
+
+
+def test_recovery_condition_rejects_each_failure_dimension_independently():
+  envelope = RecoveryEnvelope()
+
+  env, robot, left, right = _recovery_env()
+  assert recovery_condition(env, envelope).item()
+
+  right.zero_()
+  assert not recovery_condition(env, envelope).item()
+  right.fill_(True)
+
+  robot.root_link_ang_vel_b[0, 0] = envelope.max_angular_speed + 0.1
+  assert not recovery_condition(env, envelope).item()
+  robot.root_link_ang_vel_b.zero_()
+
+  robot.root_link_lin_vel_b[0, 0] = envelope.max_linear_speed + 0.1
+  assert not recovery_condition(env, envelope).item()
+  robot.root_link_lin_vel_b.zero_()
+
+  angle = envelope.max_tilt_radians + 0.05
+  robot.projected_gravity_b[0] = torch.tensor([sin(angle), 0.0, -cos(angle)])
+  assert not recovery_condition(env, envelope).item()
+  robot.projected_gravity_b[0] = torch.tensor([0.0, 0.0, -1.0])
+
+  robot.root_link_pos_w[0, 2] = envelope.min_height - 0.01
+  assert not recovery_condition(env, envelope).item()
+
+
+def test_recovery_success_requires_the_full_continuous_duration_after_interruption():
+  envelope = RecoveryEnvelope(stable_duration_s=0.25)
+  env, robot, left, right = _recovery_env(step_dt=0.001)
+  metric = _metric(env, envelope)
+
+  for _ in range(249):
+    assert metric(env).item() == 0.0
+
+  right.zero_()
+  assert metric(env).item() == 0.0
+  right.fill_(True)
+
+  for _ in range(249):
+    assert metric(env).item() == 0.0
+  assert metric(env).item() == 1.0
+
+
+def test_recovery_success_uses_an_overridden_envelope_duration():
+  env, robot, left, right = _recovery_env(step_dt=0.01)
+  metric = _metric(env, RecoveryEnvelope(stable_duration_s=0.25))
+  short = RecoveryEnvelope(stable_duration_s=0.03)
+
+  assert metric(env, short).item() == 0.0
+  assert metric(env, short).item() == 0.0
+  assert metric(env, short).item() == 1.0

--- a/tests_mjlab/test_reset_geometry.py
+++ b/tests_mjlab/test_reset_geometry.py
@@ -1,26 +1,52 @@
 import torch
 from mjlab.envs import ManagerBasedRlEnv
+from mjlab.sensor import ContactMatch, ContactSensorCfg
 from mjlab.tasks.registry import load_env_cfg
 
 import ascento_mjlab.tasks  # noqa: F401
 from ascento_mjlab.mdp.events import flat_ground_wheel_bottom_heights
 
 
-def test_recovery_resets_anchor_lowest_wheel_to_flat_support_plane():
+def test_recovery_resets_are_support_consistent_across_thousands_of_samples():
   cfg = load_env_cfg("Ascento-Recovery-Flat")
-  cfg.scene.num_envs = 64
+  cfg.scene.num_envs = 128
+  cfg.scene.sensors = (*cfg.scene.sensors, ContactSensorCfg(
+    name="nonwheel_ground_contact",
+    primary=ContactMatch(
+      mode="body",
+      pattern=r".*",
+      entity="robot",
+      exclude=(r".*_wheel$",),
+    ),
+    secondary=ContactMatch(mode="body", pattern="terrain"),
+    fields=("found", "dist"),
+    reduce="mindist",
+  ))
   env = ManagerBasedRlEnv(cfg, device="cpu")
   try:
-    observed = []
-    for _ in range(16):
+    observed_lowest = []
+    observed_nonwheel = []
+    # 128 envs * 32 resets = 4096 independently sampled recovery states.
+    for _ in range(32):
       env.reset()
       bottoms = flat_ground_wheel_bottom_heights(env)
-      observed.append(bottoms.amin(dim=1))
-    lowest = torch.cat(observed)
+      observed_lowest.append(bottoms.amin(dim=1))
 
-    # The support-aware reset should eliminate both penetration and whole-robot
-    # hovering caused solely by orientation perturbation at a fixed root height.
+      sensor = env.scene["nonwheel_ground_contact"].data
+      assert sensor.found is not None
+      observed_nonwheel.append(sensor.found.gt(0).any(dim=1))
+
+    lowest = torch.cat(observed_lowest)
+    nonwheel = torch.cat(observed_nonwheel)
+    assert lowest.numel() == 4096
+
+    # No accidental penetration or whole-robot hovering from a fixed root
+    # height: the true lower outer-wheel surface is anchored to the plane.
     assert torch.max(torch.abs(lowest)).item() <= 2.0e-3
+
+    # Recovery difficulty should come from the configured pose/velocity
+    # disturbance, not the chassis/thigh/shank starting inside the floor.
+    assert not torch.any(nonwheel).item()
   finally:
     env.close()
 

--- a/tests_mjlab/test_reset_geometry.py
+++ b/tests_mjlab/test_reset_geometry.py
@@ -1,0 +1,36 @@
+import torch
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.tasks.registry import load_env_cfg
+
+import ascento_mjlab.tasks  # noqa: F401
+from ascento_mjlab.mdp.events import flat_ground_wheel_bottom_heights
+
+
+def test_recovery_resets_anchor_lowest_wheel_to_flat_support_plane():
+  cfg = load_env_cfg("Ascento-Recovery-Flat")
+  cfg.scene.num_envs = 64
+  env = ManagerBasedRlEnv(cfg, device="cpu")
+  try:
+    observed = []
+    for _ in range(16):
+      env.reset()
+      bottoms = flat_ground_wheel_bottom_heights(env)
+      observed.append(bottoms.amin(dim=1))
+    lowest = torch.cat(observed)
+
+    # The support-aware reset should eliminate both penetration and whole-robot
+    # hovering caused solely by orientation perturbation at a fixed root height.
+    assert torch.max(torch.abs(lowest)).item() <= 2.0e-3
+  finally:
+    env.close()
+
+
+def test_all_flat_tasks_use_support_aware_root_resets():
+  for task in (
+    "Ascento-Balance-Flat",
+    "Ascento-Velocity-Flat",
+    "Ascento-Recovery-Flat",
+    "Ascento-Jump-Flat",
+  ):
+    cfg = load_env_cfg(task)
+    assert cfg.events["reset_supported_pose"].func.__name__ == "reset_root_state_supported"

--- a/tests_mjlab/test_task_config.py
+++ b/tests_mjlab/test_task_config.py
@@ -92,14 +92,34 @@ def test_all_flat_task_configs_construct_and_step(task_id):
   env.close()
 
 
-def test_jump_state_is_synchronized_before_jump_dependent_rewards():
+def test_jump_state_sync_is_first_and_base_rewards_are_phase_aware():
   cfg = load_env_cfg("Ascento-Jump-Flat")
 
   assert "update_jump_state" not in cfg.events
   reward_names = list(cfg.rewards)
+  assert reward_names[0] == "jump_state_sync"
+  assert cfg.rewards["height"].func.__name__ == "jump_nominal_height_tracking"
+  assert cfg.rewards["angular_rate"].func.__name__ == "jump_angular_rate_penalty"
+  assert cfg.rewards["planar_speed"].func.__name__ == "jump_planar_speed_penalty"
+  assert cfg.rewards["crouch"].func.__name__ == "jump_crouch"
+  assert cfg.rewards["thrust"].func.__name__ == "jump_thrust"
+  assert cfg.rewards["distance_tracking"].func.__name__ == "jump_distance_tracking"
+  assert cfg.rewards["landing_softness"].func.__name__ == "jump_landing_softness"
   assert reward_names.index("jump_state_sync") < reward_names.index("takeoff")
   assert reward_names.index("jump_state_sync") < reward_names.index("landing")
   assert cfg.sim.mujoco.timestep * cfg.decimation == pytest.approx(0.01)
+
+
+def test_jump_observation_contains_phase_and_remaining_distance():
+  cfg = load_env_cfg("Ascento-Jump-Flat", play=True)
+  cfg.scene.num_envs = 1
+  env = ManagerBasedRlEnv(cfg, device="cpu")
+  try:
+    obs, _ = env.reset()
+    # Balance actor (38) + motion command (6) + jump state (6).
+    assert obs["actor"].shape[-1] == 50
+  finally:
+    env.close()
 
 
 def test_custom_sim_timestep_reaches_actuator():


### PR DESCRIPTION
## Summary

This PR turns the remaining pre-long-run correctness concerns into executable semantics and regression gates.

### Jump correctness
- add a real `ManagerBasedRlEnv` transition-alignment regression for contact / airborne / takeoff / landing / reward pulses (#57)
- make one-shot jump requests lossless across command-manager timing with a persistent request generation
- add explicit jump phases and make inherited balance rewards phase-aware (#22)
- replace unsigned joint-displacement crouch shaping with physical body-height crouch shaping (#11)
- define jump distance in the takeoff heading frame and reward/evaluate landing distance error (#10)
- retain first-contact pre-impact vertical speed as the landing impact metric (#12)
- use simultaneous limiting-wheel clearance instead of the highest wheel (#13)
- make `jump_gate_v1` authoritative for takeoff, landing, distance, impact and clearance

### Recovery / reset correctness
- add dedicated `RecoverySuccess` semantic tests for support, height, tilt, linear/angular velocity, and uninterrupted stable duration (#62)
- explicitly test the 249 ms interruption edge
- make flat-ground root resets support-aware so pose perturbations do not create fixed-height wheel penetration/hover artifacts (#21)
- account for the actual vertical support extent of tilted wheel cylinders rather than assuming `wheel_center_z - radius`
- sample **4096** recovery reset states and require the lower wheel support error to stay within 2 mm
- explicitly assert zero chassis/thigh/shank-to-ground contacts across those 4096 reset states
- apply the same support-consistency rule to deterministic evaluator resets unless a scenario intentionally requests non-zero Z

### Evaluator preflight
- add `ascento-preflight-evaluator`
- run balance, velocity and recovery scenarios twice with identical checkpoint/scenario/seed and require deterministic equality
- fail on non-finite metrics, ambiguous termination reasons, empty/invalid episodes, or unfinished vector slots
- run a mixed-horizon vector batch and verify successful slots end exactly at their requested horizon
- add `scripts/preflight_long_run.sh` for smoke -> model inspection -> full tests -> 512-env two-iteration training smoke -> evaluator preflight

### Sequencing
Terrain/high-landing geometry remains deliberately blocked by #30. This PR does not claim that stage is ready.

## Validation

GitHub Actions run #160 (`33963206292`) is green on the current PR head:
- backend: `uv run --frozen --extra cpu python -m pytest -q tests_mjlab` -> **65 passed, 1 skipped**
- dashboard backend: green
- frontend: green
- maintenance / Docker compose and Dockerfile validation: green

Issue-specific evidence has been attached before closure:
- #57 closed after the real same-transition contact/takeoff/landing regression passed.
- #62 closed after the dedicated RecoverySuccess semantics and evaluator-path tests passed.
- #21 closed after the 4096-state support/non-wheel-contact reset audit passed.

The **final production-machine preflight is still outstanding**. `Marcus_Computer` currently responds to the remote-device ping, but the terminal/session channel returns `Not connected`, so I have not claimed execution of the real balance/velocity/recovery checkpoint evaluator, deterministic repeat, target-machine import-order check, or 512-env CUDA training smoke.

Therefore #53 and tracking issue #74 remain open, and this PR remains draft until that production-host evidence is available.

Closes the code gaps behind #10, #11, #12, #13, #21, #22, #53, #57 and #62, subject to the remaining production-machine validation described above.