### PR TITLE
Add host update supervisor and private Tailscale dashboard access

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -17,6 +17,8 @@ on:
       - '.dockerignore'
       - '.github/workflows/dashboard-ci.yml'
   push:
+    branches:
+      - main
     paths:
       - 'dashboard/**'
       - 'scripts/**'
@@ -32,17 +34,21 @@ on:
       - '.dockerignore'
       - '.github/workflows/dashboard-ci.yml'
 
+concurrency:
+  group: dashboard-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend:
     runs-on: ubuntu-latest
     env:
       MUJOCO_GL: disable
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
       - run: uv run --frozen --extra cpu python -m pytest -q tests_mjlab
 
   dashboard-backend:
@@ -50,11 +56,11 @@ jobs:
     env:
       MUJOCO_GL: disable
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
       - run: bash -n scripts/run_dashboard.sh scripts/maintain.sh scripts/install_supervisor.sh scripts/setup_tailscale.sh
       - run: bash scripts/maintain.sh --help
       - run: bash scripts/install_supervisor.sh --help
@@ -65,7 +71,7 @@ jobs:
   maintenance-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           mkdir -p .maintenance/supervisor
           cat > .maintenance/compose.env <<'EOF'
@@ -85,8 +91,8 @@ jobs:
       run:
         working-directory: dashboard/frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
       - run: npm ci

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: uv run --frozen --extra cpu python -m pytest -q tests_mjlab
 
   dashboard-backend:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: bash -n scripts/run_dashboard.sh scripts/maintain.sh scripts/install_supervisor.sh scripts/setup_tailscale.sh
       - run: bash scripts/maintain.sh --help
       - run: bash scripts/install_supervisor.sh --help

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -55,8 +55,11 @@ jobs:
         with:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v6
-      - run: bash -n scripts/run_dashboard.sh scripts/maintain.sh
+      - run: bash -n scripts/run_dashboard.sh scripts/maintain.sh scripts/install_supervisor.sh scripts/setup_tailscale.sh
       - run: bash scripts/maintain.sh --help
+      - run: bash scripts/install_supervisor.sh --help
+      - run: bash scripts/setup_tailscale.sh --help
+      - run: python -m py_compile scripts/host_supervisor.py dashboard/supervisor_client.py
       - run: uv run --frozen --extra cpu --extra dashboard python -m pytest -q tests_dashboard
 
   maintenance-config:
@@ -64,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          mkdir -p .maintenance
+          mkdir -p .maintenance/supervisor
           cat > .maintenance/compose.env <<'EOF'
           ASCENTO_COMPUTE_EXTRA=cpu
           ASCENTO_REPOSITORY_COMMIT=testcommit
@@ -73,6 +76,7 @@ jobs:
           EOF
       - run: docker compose --env-file .maintenance/compose.env -f docker/compose.yaml config >/dev/null
       - run: docker compose --env-file .maintenance/compose.env -f docker/compose.yaml -f docker/compose.gpu.yaml config >/dev/null
+      - run: TS_AUTHKEY=test-key docker compose --env-file .maintenance/compose.env -f docker/compose.yaml -f docker/compose.tailscale.yaml config >/dev/null
       - run: docker build --check -f docker/Dockerfile .
 
   frontend:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The maintainer:
   remain in the active image;
 - starts the dashboard container on `127.0.0.1:8000` by default;
 - preserves existing runs and records pre-update Git provenance for legacy runs
-  that did not already record their repository commit.
+  that did not already record their repository commit;
+- preserves the optional Tailscale dashboard ingress after it has been enrolled.
 
 `cpu` and `cu128` are declared as conflicting extras, so only one can be
 installed at a time. All other compatible optional extras are installed.
@@ -67,6 +68,55 @@ contents of the current lockfile.
 The script refuses to overwrite tracked local changes or local-only commits
 unless `--force` is explicitly supplied. See `bash scripts/maintain.sh --help`
 for CPU/GPU, install-directory, and Docker options.
+
+### Dashboard host updates
+
+The Dashboard's **System** page can compare the local checkout with
+`origin/main` and request an update, but the web container never receives the
+Docker socket or arbitrary host shell access. Install the small host-side
+supervisor once:
+
+```bash
+bash scripts/install_supervisor.sh
+```
+
+The supervisor runs as the workstation user under systemd and exposes only a
+restricted Unix socket to the Dashboard. It accepts repository-status checks and
+a guarded request to run the existing `scripts/maintain.sh`; it does not accept
+arbitrary commands, branches, paths, or Docker operations from the web API.
+
+GUI-triggered updates are refused while training is active, while the checkout
+is dirty, when local-only commits exist, when the checkout is not on `main`, or
+when `origin/main` cannot be verified. When an update is accepted, the supervisor
+continues running outside Docker while the Dashboard is rebuilt and restarted.
+
+### Remote Dashboard over Tailscale
+
+The maintained Docker stack can expose the Dashboard privately to your Tailscale
+tailnet without opening it to the LAN or public internet. Enroll it once on the
+workstation:
+
+```bash
+bash scripts/setup_tailscale.sh
+```
+
+Supply a Tailscale auth key at the hidden prompt or through `TS_AUTHKEY`. The
+credential is used for initial enrollment only; after persistent Tailscale state
+has been created, the sidecar is recreated without the credential in its Docker
+environment. For OAuth client-secret enrollment, also provide the required
+advertised tag, for example:
+
+```bash
+ASCENTO_TAILSCALE_EXTRA_ARGS='--advertise-tags=tag:ascento' \
+TS_AUTHKEY='<oauth-client-secret>' \
+bash scripts/setup_tailscale.sh
+```
+
+The Tailscale sidecar owns the Dashboard's network namespace. Tailnet peers can
+open port `8000` on its Tailscale IP or MagicDNS name, while local access remains
+available on `127.0.0.1:8000`. The separate `ascento-mjlab` service is not joined
+to that Tailnet ingress. Tailscale Funnel is not enabled; your Tailnet grants or
+ACLs determine who can reach the private Dashboard.
 
 ## Manual setup
 
@@ -190,11 +240,22 @@ docker compose -f docker/compose.yaml build
 docker compose -f docker/compose.yaml -f docker/compose.gpu.yaml build
 ```
 
+The optional Tailnet overlay is normally managed by `scripts/setup_tailscale.sh`:
+
+```bash
+docker compose \
+  -f docker/compose.yaml \
+  -f docker/compose.tailscale.yaml config
+```
+
 The maintenance script normally handles the build arguments and starts the
 `dashboard` service automatically. Training logs, checkpoints, and captures are
 bind-mounted from the repository, so container rebuilds do not delete runs.
-The dashboard mount is read-only and defaults to the shared `logs/rsl_rl`
-artifact root.
+The Dashboard has read-write access to `logs/` because managed runs create their
+status, TensorBoard output, logs, and checkpoints there; separate
+`checkpoints/`, `captures/`, and `evaluations/` mounts stay read-only. The only
+host-control mount is the restricted supervisor Unix socket directory; Docker's
+control socket is never mounted into the Dashboard.
 
 The dashboard compares each run's recorded Git commit with the repository
 version serving the UI. Runs from older commits are labelled `OUTDATED` in the
@@ -217,7 +278,10 @@ specific important plant regression.
 - `src/ascento_mjlab/mdp/`: Ascento observations, rewards, resets, semantics, metrics.
 - `src/ascento_mjlab/tasks/`: balance, velocity, recovery, and flat-jump configs.
 - `src/ascento_mjlab/tools/`: smoke, model inspection, plant comparison, capture, clip processing, and motion-quality ranking.
+- `dashboard/`: run-management, monitoring, System/update UI, and host-supervisor client.
+- `scripts/host_supervisor.py`: fixed-operation host update boundary.
 - `tests_mjlab/`: migration unit and integration tests.
+- `tests_dashboard/`: dashboard, run-control, supervisor, and update API tests.
 
 The old JAX/MJX/Brax implementation remains available only in Git history and
 the `archive/mjx-playground` branch during migration validation.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,13 +1,14 @@
 # Ascento Training Dashboard
 
-A local web control plane for mjlab/RSL-RL training over Tailscale. The dashboard
-monitors existing artifacts and can also start/stop managed training runs. PPO
-still belongs to mjlab/RSL-RL; the dashboard owns run lifecycle, provenance,
-console capture, health reporting, and comparison.
+A local web control plane for mjlab/RSL-RL training. The dashboard monitors
+existing artifacts, starts/stops managed training runs, compares results, reports
+repository state, and can request a guarded update to the newest `origin/main`.
+PPO still belongs to mjlab/RSL-RL; the dashboard owns run lifecycle, provenance,
+console capture, health reporting, comparison, and the user-facing control flow.
 
 ## Run management
 
-The **Runs** page is now the default dashboard view. It supports:
+The **Runs** page supports:
 
 - starting a training run from the browser;
 - human-readable names independent of machine artifact directory names;
@@ -27,6 +28,107 @@ and only escalates to terminate/kill if the process does not exit.
 Run metadata is stored next to the run as `run_metadata.json`. The artifact
 directory remains machine-oriented and immutable; display names and notes can be
 changed later without breaking paths.
+
+## Host supervisor and repository updates
+
+The **System** page shows:
+
+- checked-out branch and exact local commit;
+- current `origin/main` commit, ahead/behind counts and incoming commit subjects;
+- dirty working-tree state;
+- active training runs that block maintenance;
+- last/current update state;
+- Tailscale sidecar state, MagicDNS name and Tailnet IPs.
+
+The Dashboard container does **not** receive `/var/run/docker.sock`, a repository
+mount, `sudo`, or an arbitrary command endpoint. A small host-side supervisor
+runs as the workstation user and accepts only two operations over a Unix-domain
+socket:
+
+1. `status` — fetch/compare Git state and report update/Tailnet status;
+2. `update` — invoke the repository's existing `scripts/maintain.sh` against
+   `main` after safety checks pass.
+
+Install that boundary once after updating the checkout:
+
+```bash
+bash scripts/install_supervisor.sh
+```
+
+The installer creates a boot-persistent systemd service. The process runs as the
+workstation user, with Docker-group access only so `maintain.sh` can rebuild the
+project stack. The Dashboard receives only `.maintenance/supervisor/supervisor.sock`
+through a bind mount.
+
+The supervisor refuses a GUI-triggered update when:
+
+- the checkout is not on `main`;
+- tracked files are modified;
+- the checkout has local-only commits;
+- `origin/main` cannot be refreshed;
+- another update is running;
+- any run is still `starting`, `running`, or `stopping`.
+
+When accepted, the supervisor starts `maintain.sh` in an independent process
+session and writes progress to `.maintenance/update-state.json` and
+`.maintenance/update.log`. The Dashboard and its Tailnet sidecar may disappear
+briefly while Docker rebuilds, but the supervisor remains alive outside Docker
+and finishes the update. If Tailnet access was enabled, `maintain.sh` includes
+the Tailscale Compose overlay again and the persistent node reconnects.
+
+System-control API:
+
+- `GET /api/system` — cached host/Tailnet/update state;
+- `GET /api/system?refresh=true` — force a fresh `origin/main` check;
+- `POST /api/system/update` — request the guarded maintenance update.
+
+## Remote access through Tailscale
+
+Only the Dashboard-facing service is intentionally exposed to the Tailnet. The
+`ascento-mjlab` service is not attached to the Tailscale sidecar and no LAN or
+public-internet port is opened.
+
+Tailscale's official container runs as a sidecar and the Dashboard shares its
+network namespace. Local workstation access remains available on
+`127.0.0.1:8000`; Tailnet peers can connect to port `8000` on the node's
+Tailscale IP or MagicDNS name.
+
+Enroll the sidecar once:
+
+```bash
+bash scripts/setup_tailscale.sh
+```
+
+The script accepts a Tailscale auth key or OAuth client secret through the
+hidden prompt, or through the `TS_AUTHKEY` environment variable. It uses that
+credential only for initial enrollment. After Tailscale state has been persisted
+in the `tailscale-dashboard-state` Docker volume, the sidecar is immediately
+recreated without the credential so the secret is no longer present in Docker's
+inspectable container environment.
+
+Optional hostname:
+
+```bash
+ASCENTO_TAILSCALE_HOSTNAME=ascento-workstation \
+  bash scripts/setup_tailscale.sh
+```
+
+After enrollment the script prints the remote URL, normally similar to:
+
+```text
+http://ascento-dashboard.<tailnet-name>.ts.net:8000
+```
+
+The HTTP payload travels inside Tailscale's encrypted tunnel; this configuration
+does not enable Tailscale Funnel and does not expose the Dashboard publicly.
+Your normal Tailnet grants/ACLs still determine which users/devices may reach the
+node.
+
+The Tailscale sidecar uses kernel networking (`/dev/net/tun`) and persistent
+state. `scripts/maintain.sh` remembers enrollment via the ignored local marker
+`.maintenance/tailscale-enabled` and automatically includes
+`docker/compose.tailscale.yaml` on later rebuilds. No auth key is stored in the
+repository.
 
 ## What the monitor shows
 
@@ -58,7 +160,15 @@ Set `ASCENTO_ARTIFACT_ROOT` once to override it for both processes.
 
 ## Install
 
-From the repository root:
+The maintained path is:
+
+```bash
+bash scripts/maintain.sh
+bash scripts/install_supervisor.sh
+bash scripts/setup_tailscale.sh   # optional, but required for remote Tailnet GUI access
+```
+
+For a manual development environment:
 
 ```bash
 uv sync --frozen --extra cu128 --extra dashboard
@@ -73,42 +183,13 @@ Use `--extra cpu` instead of `--extra cu128` on a CPU-only machine.
 For frontend development, run `npm run dev` in `dashboard/frontend`; Vite proxies
 `/api` requests to `127.0.0.1:8000`.
 
-## Start the dashboard
-
-Use the project interpreter through uv:
-
-```bash
-uv run --frozen --extra dashboard python -m uvicorn dashboard.app:app \
-  --host 127.0.0.1 --port 8000
-```
-
-Or use:
-
-```bash
-./scripts/run_dashboard.sh
-```
-
-The production server intentionally binds only to `127.0.0.1:8000`. To make it
-available to your tailnet without exposing it on the LAN:
-
-```bash
-tailscale serve --bg 8000
-```
-
-Open the HTTPS Tailscale Serve URL from another device on the same tailnet. Do
-not use Tailscale Funnel for this private control surface.
-
-The maintained Docker dashboard mounts `logs/` read-write because managed runs
-create their status, logs, TensorBoard files and checkpoints under the shared
-artifact root. `checkpoints/`, `captures/`, and `evaluations/` remain read-only in
-the dashboard service.
-
 ## API
 
 Read/monitor endpoints:
 
 - `GET /api/health`
 - `GET /api/config`
+- `GET /api/system`
 - `GET /api/runs`
 - `GET /api/runs/<id>`
 - `GET /api/runs/<id>/summary.json`
@@ -116,8 +197,9 @@ Read/monitor endpoints:
 - `GET /api/runs/<id>/logs`
 - `GET /api/runs/<id>/logs/stream`
 
-Run-control endpoints:
+Control endpoints:
 
+- `POST /api/system/update` — guarded update to newest `origin/main`;
 - `POST /api/runs` — start a managed run;
 - `PATCH /api/runs/<id>` — edit name/notes/tags/purpose/lineage;
 - `POST /api/runs/<id>/stop` — request a graceful stop;
@@ -158,4 +240,6 @@ as environment-step throughput rather than iteration throughput.
 The backend validates its artifact root during startup. If the configured path
 is a file, cannot be read/searched, or later proves unwritable when starting a
 run, the error names the artifact root. A missing frontend build is non-fatal
-and appears as a startup warning in `/api/health`.
+and appears as a startup warning in `/api/health`. A missing host supervisor does
+not prevent monitoring/run management; the System page simply disables host
+updates until `scripts/install_supervisor.sh` has been run.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -19,6 +19,11 @@ from dashboard.health import (
 )
 from dashboard.monitor import tail_lines, training_log_path
 from dashboard.run_service import RunService
+from dashboard.supervisor_client import (
+    SupervisorClient,
+    SupervisorRejected,
+    SupervisorUnavailable,
+)
 from dashboard.versioning import current_repository_version
 
 CONFIG = load_config()
@@ -26,8 +31,9 @@ STARTUP_WARNINGS = validate_startup(CONFIG, create_artifact_root=False)
 ARTIFACT_ROOT = CONFIG.artifact_root
 FRONTEND_DIST = CONFIG.frontend_dist
 RUN_SERVICE = RunService(ARTIFACT_ROOT, stale_after_seconds=CONFIG.stale_after_seconds)
+SUPERVISOR = SupervisorClient()
 
-app = FastAPI(title="Ascento Training Monitor", version="2.0")
+app = FastAPI(title="Ascento Training Monitor", version="2.1")
 
 
 class RunCreateRequest(BaseModel):
@@ -119,6 +125,35 @@ def configuration():
         "startup_warnings": STARTUP_WARNINGS,
         "repository_version": current_repository_version(),
     }
+
+
+@app.get("/api/system")
+def system_status(refresh: bool = False):
+    """Return host repository/update/Tailnet state through the restricted supervisor."""
+    try:
+        return {"connected": True, **SUPERVISOR.status(refresh=refresh)}
+    except SupervisorUnavailable as error:
+        return {
+            "connected": False,
+            "error": str(error),
+            "repository": None,
+            "active_runs": [],
+            "update": {"status": "unavailable"},
+            "tailscale": {"enabled": False, "connected": False},
+            "can_update": False,
+            "update_blockers": ["host supervisor is unavailable"],
+        }
+
+
+@app.post("/api/system/update", status_code=202)
+def system_update():
+    """Ask the host supervisor to update to the newest origin/main."""
+    try:
+        return SUPERVISOR.update()
+    except SupervisorUnavailable as error:
+        raise HTTPException(status_code=503, detail=str(error)) from error
+    except SupervisorRejected as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
 
 
 @app.get("/api/runs")
@@ -268,6 +303,7 @@ def index():
             "api": "/api/runs",
             "health": "/api/health",
             "config": "/api/config",
+            "system": "/api/system",
         }
     )
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -146,8 +146,13 @@ def system_status(refresh: bool = False):
 
 
 @app.post("/api/system/update", status_code=202)
-def system_update():
+def system_update(request: Request):
     """Ask the host supervisor to update to the newest origin/main."""
+    # Requiring a non-simple custom header prevents cross-site forms and simple
+    # browser requests from invoking the privileged host boundary. Tailnet
+    # grants/ACLs remain the authentication boundary for reaching this service.
+    if request.headers.get("x-ascento-control") != "1":
+        raise HTTPException(status_code=403, detail="missing dashboard control header")
     try:
         return SUPERVISOR.update()
     except SupervisorUnavailable as error:

--- a/dashboard/frontend/src/Root.jsx
+++ b/dashboard/frontend/src/Root.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import MonitorPage from './App'
 import RunsPage from './RunsPage'
+import SystemPage from './SystemPage'
 import './runs.css'
 
 function Root() {
@@ -13,9 +14,12 @@ function Root() {
         <div className="dashboard-nav-tabs">
           <button className={page === 'runs' ? 'active' : ''} onClick={() => setPage('runs')}>Runs</button>
           <button className={page === 'monitor' ? 'active' : ''} onClick={() => setPage('monitor')}>Monitor</button>
+          <button className={page === 'system' ? 'active' : ''} onClick={() => setPage('system')}>System</button>
         </div>
       </nav>
-      {page === 'runs' ? <RunsPage /> : <MonitorPage />}
+      {page === 'runs' && <RunsPage />}
+      {page === 'monitor' && <MonitorPage />}
+      {page === 'system' && <SystemPage />}
     </>
   )
 }

--- a/dashboard/frontend/src/SystemPage.jsx
+++ b/dashboard/frontend/src/SystemPage.jsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from 'react'
+import './system.css'
+
+const POLL_MS = 10000
+
+function shortCommit(value) {
+  return value ? String(value).slice(0, 10) : 'unknown'
+}
+
+function fmtDate(value) {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString()
+}
+
+function StatusPill({ good, children }) {
+  return <span className={`system-pill ${good ? 'good' : 'warn'}`}>{children}</span>
+}
+
+function SystemPage() {
+  const [status, setStatus] = useState(null)
+  const [error, setError] = useState('')
+  const [action, setAction] = useState('')
+
+  async function fetchJson(url, options) {
+    const response = await fetch(url, options)
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(body.detail || `${response.status} ${response.statusText}`)
+    return body
+  }
+
+  async function refresh(force = false) {
+    try {
+      const data = await fetchJson(`/api/system${force ? '?refresh=true' : ''}`)
+      setStatus(data)
+      setError('')
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    refresh(true)
+    const timer = setInterval(() => refresh(false), POLL_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  async function updateSystem() {
+    setAction('Starting update…')
+    try {
+      await fetchJson('/api/system/update', { method: 'POST' })
+      setAction('Update started. The dashboard may disconnect briefly while containers rebuild.')
+      await refresh(false)
+    } catch (err) {
+      setAction(`Update not started: ${err.message}`)
+      await refresh(true)
+    }
+  }
+
+  const repository = status?.repository || {}
+  const update = status?.update || {}
+  const tailscale = status?.tailscale || {}
+  const activeRuns = status?.active_runs || []
+  const blockers = status?.update_blockers || []
+  const incoming = repository.incoming_commits || []
+  const updateRunning = update.status === 'running'
+  const updateAvailable = Boolean(repository.update_available)
+
+  const headline = useMemo(() => {
+    if (!status?.connected) return 'Host supervisor unavailable'
+    if (updateRunning) return 'Updating workstation'
+    if (updateAvailable) return `${repository.behind_by || 0} commit${repository.behind_by === 1 ? '' : 's'} available`
+    return 'Repository is current'
+  }, [status, repository.behind_by, updateAvailable, updateRunning])
+
+  return (
+    <main className="system-page">
+      <header className="system-header">
+        <div>
+          <div className="system-eyebrow">WORKSTATION / CONTROL</div>
+          <h1>System</h1>
+          <p>Repository updates, host-control health, and remote Tailnet access.</p>
+        </div>
+        <button className="secondary-button" onClick={() => refresh(true)}>Refresh remote status</button>
+      </header>
+
+      {error && <div className="system-banner danger">{error}</div>}
+      {action && <div className="system-banner">{action}</div>}
+
+      <section className="system-hero panel-like">
+        <div>
+          <div className="system-section-label">Update state</div>
+          <h2>{headline}</h2>
+          <p>
+            Local <code>{shortCommit(repository.local_commit)}</code>
+            {' · '}origin/main <code>{shortCommit(repository.remote_commit)}</code>
+          </p>
+        </div>
+        <div className="system-hero-actions">
+          <StatusPill good={Boolean(status?.connected)}>
+            {status?.connected ? 'Supervisor connected' : 'Supervisor offline'}
+          </StatusPill>
+          <button
+            className="primary-button"
+            disabled={!status?.can_update || updateRunning}
+            onClick={updateSystem}
+          >
+            {updateRunning ? 'Updating…' : updateAvailable ? 'Update to latest main' : 'Up to date'}
+          </button>
+        </div>
+      </section>
+
+      <section className="system-grid">
+        <article className="panel-like system-card">
+          <div className="system-card-title">Repository</div>
+          <dl className="system-kv">
+            <div><dt>Branch</dt><dd>{repository.branch || '—'}</dd></div>
+            <div><dt>Local commit</dt><dd><code>{shortCommit(repository.local_commit)}</code></dd></div>
+            <div><dt>Remote main</dt><dd><code>{shortCommit(repository.remote_commit)}</code></dd></div>
+            <div><dt>Ahead / behind</dt><dd>{repository.ahead_by ?? '—'} / {repository.behind_by ?? '—'}</dd></div>
+            <div><dt>Tracked changes</dt><dd>{repository.dirty ? 'dirty' : 'clean'}</dd></div>
+            <div><dt>Checked</dt><dd>{fmtDate(status?.checked_at)}</dd></div>
+          </dl>
+          {repository.remote_error && <div className="inline-warning">Remote check: {repository.remote_error}</div>}
+        </article>
+
+        <article className="panel-like system-card">
+          <div className="system-card-title">Tailnet access</div>
+          <div className="tailnet-state">
+            <StatusPill good={Boolean(tailscale.connected)}>
+              {tailscale.connected ? 'Connected' : tailscale.enabled ? 'Disconnected' : 'Not enrolled'}
+            </StatusPill>
+          </div>
+          <dl className="system-kv">
+            <div><dt>MagicDNS</dt><dd>{tailscale.dns_name || '—'}</dd></div>
+            <div><dt>Tailscale IP</dt><dd>{tailscale.ips?.join(', ') || '—'}</dd></div>
+          </dl>
+          {tailscale.url ? (
+            <a className="tailnet-link" href={tailscale.url} target="_blank" rel="noreferrer">
+              Open remote dashboard
+            </a>
+          ) : (
+            <div className="system-help">
+              Enroll once on the workstation with <code>scripts/setup_tailscale.sh</code> and a Tailscale auth key.
+              The key is not committed or retained in the running container after enrollment.
+            </div>
+          )}
+          {tailscale.error && <div className="inline-warning">{tailscale.error}</div>}
+        </article>
+
+        <article className="panel-like system-card">
+          <div className="system-card-title">Host supervisor</div>
+          <p className="system-help">
+            The web container has no Docker socket and no arbitrary shell endpoint. It can request only repository status or a guarded maintenance update over a Unix socket.
+          </p>
+          {!status?.connected && (
+            <div className="inline-warning">
+              Install the host boundary once with <code>scripts/install_supervisor.sh</code>.
+            </div>
+          )}
+          {status?.error && <div className="inline-warning">{status.error}</div>}
+        </article>
+
+        <article className="panel-like system-card">
+          <div className="system-card-title">Last update</div>
+          <dl className="system-kv">
+            <div><dt>Status</dt><dd>{update.status || 'idle'}</dd></div>
+            <div><dt>Started</dt><dd>{fmtDate(update.started_at)}</dd></div>
+            <div><dt>Finished</dt><dd>{fmtDate(update.finished_at)}</dd></div>
+            <div><dt>From</dt><dd><code>{shortCommit(update.from_commit)}</code></dd></div>
+            <div><dt>Target</dt><dd><code>{shortCommit(update.target_commit)}</code></dd></div>
+            <div><dt>Exit code</dt><dd>{update.return_code ?? '—'}</dd></div>
+          </dl>
+        </article>
+      </section>
+
+      {blockers.length > 0 && (
+        <section className="panel-like system-section">
+          <div className="system-card-title">Why update is blocked</div>
+          <ul>{blockers.map((item) => <li key={item}>{item}</li>)}</ul>
+        </section>
+      )}
+
+      {activeRuns.length > 0 && (
+        <section className="panel-like system-section">
+          <div className="system-card-title">Active runs</div>
+          <p>Repository updates are deliberately disabled while training is active so rebuilding the Dashboard cannot terminate a run.</p>
+          <div className="active-run-list">
+            {activeRuns.map((run) => (
+              <div key={`${run.path}:${run.state}`}>
+                <strong>{run.name}</strong><span>{run.state}</span><code>{run.path}</code>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {incoming.length > 0 && (
+        <section className="panel-like system-section">
+          <div className="system-card-title">Incoming commits</div>
+          <div className="incoming-list">
+            {incoming.map((commit) => (
+              <div key={commit.commit}>
+                <code>{shortCommit(commit.commit)}</code>
+                <span>{commit.subject}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="system-banner subtle">
+        An update can temporarily interrupt the web connection while Docker rebuilds the Dashboard and Tailscale sidecar. The host supervisor remains outside Docker, finishes the update, and the persistent Tailnet node reconnects automatically.
+      </section>
+    </main>
+  )
+}
+
+export default SystemPage

--- a/dashboard/frontend/src/SystemPage.jsx
+++ b/dashboard/frontend/src/SystemPage.jsx
@@ -48,7 +48,10 @@ function SystemPage() {
   async function updateSystem() {
     setAction('Starting update…')
     try {
-      await fetchJson('/api/system/update', { method: 'POST' })
+      await fetchJson('/api/system/update', {
+        method: 'POST',
+        headers: { 'X-Ascento-Control': '1' },
+      })
       setAction('Update started. The dashboard may disconnect briefly while containers rebuild.')
       await refresh(false)
     } catch (err) {

--- a/dashboard/frontend/src/system.css
+++ b/dashboard/frontend/src/system.css
@@ -1,0 +1,256 @@
+.system-page {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 28px 28px 64px;
+}
+
+.system-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.system-header h1 {
+  margin: 3px 0 8px;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+}
+
+.system-header p,
+.system-help {
+  color: #8f9aab;
+  line-height: 1.55;
+}
+
+.system-eyebrow,
+.system-section-label {
+  color: #6f7c91;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.panel-like {
+  border: 1px solid #273247;
+  background: #111825;
+  border-radius: 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.16);
+}
+
+.system-hero {
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+
+.system-hero h2 {
+  margin: 6px 0;
+  font-size: 1.55rem;
+}
+
+.system-hero p {
+  margin: 0;
+  color: #9ba7b9;
+}
+
+.system-hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.system-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.system-card,
+.system-section {
+  padding: 20px;
+}
+
+.system-card-title {
+  font-weight: 800;
+  margin-bottom: 16px;
+  font-size: 1.03rem;
+}
+
+.system-kv {
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.system-kv > div {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.8fr) minmax(0, 1.2fr);
+  gap: 12px;
+  align-items: baseline;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #202a3c;
+}
+
+.system-kv dt {
+  color: #778399;
+}
+
+.system-kv dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.system-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 800;
+  border: 1px solid;
+}
+
+.system-pill.good {
+  color: #98e5ba;
+  border-color: #28583f;
+  background: #11291e;
+}
+
+.system-pill.warn {
+  color: #f5c988;
+  border-color: #674b27;
+  background: #2b2113;
+}
+
+.primary-button,
+.secondary-button,
+.tailnet-link {
+  border-radius: 9px;
+  font-weight: 800;
+  font-size: 0.9rem;
+  padding: 10px 14px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.primary-button {
+  background: #e9eef7;
+  color: #101722;
+  border: 1px solid #e9eef7;
+}
+
+.primary-button:disabled {
+  opacity: 0.42;
+  cursor: default;
+}
+
+.secondary-button,
+.tailnet-link {
+  background: #172133;
+  color: #d8e1ee;
+  border: 1px solid #344159;
+}
+
+.tailnet-link {
+  display: inline-block;
+  margin-top: 16px;
+}
+
+.tailnet-state {
+  margin-bottom: 16px;
+}
+
+.system-banner {
+  padding: 13px 16px;
+  border: 1px solid #34435b;
+  border-radius: 10px;
+  background: #172234;
+  margin: 0 0 18px;
+  color: #ced8e7;
+}
+
+.system-banner.danger,
+.inline-warning {
+  border-color: #654044;
+  background: #2a181c;
+  color: #f1adb5;
+}
+
+.system-banner.subtle {
+  margin-top: 18px;
+  color: #98a5b8;
+  background: #101725;
+}
+
+.inline-warning {
+  margin-top: 14px;
+  border: 1px solid #654044;
+  border-radius: 8px;
+  padding: 10px 12px;
+  line-height: 1.45;
+}
+
+.system-section {
+  margin-top: 18px;
+}
+
+.system-section p,
+.system-section li {
+  color: #9ba7b9;
+  line-height: 1.5;
+}
+
+.incoming-list,
+.active-run-list {
+  display: grid;
+  gap: 8px;
+}
+
+.incoming-list > div {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 1fr);
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px solid #202a3c;
+}
+
+.active-run-list > div {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 100px minmax(220px, 1fr);
+  gap: 12px;
+  align-items: center;
+  padding: 9px 0;
+  border-bottom: 1px solid #202a3c;
+}
+
+.system-page code {
+  color: #b9c8de;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+@media (max-width: 900px) {
+  .system-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .system-header,
+  .system-hero {
+    flex-direction: column;
+  }
+
+  .system-hero-actions {
+    justify-content: flex-start;
+  }
+
+  .active-run-list > div {
+    grid-template-columns: 1fr;
+  }
+}

--- a/dashboard/supervisor_client.py
+++ b/dashboard/supervisor_client.py
@@ -1,0 +1,62 @@
+"""Restricted Unix-socket client for the host maintenance supervisor."""
+from __future__ import annotations
+
+import json
+import os
+import socket
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SOCKET = Path("/run/ascento-supervisor/supervisor.sock")
+
+
+class SupervisorUnavailable(RuntimeError):
+    pass
+
+
+class SupervisorRejected(RuntimeError):
+    pass
+
+
+class SupervisorClient:
+    def __init__(self, socket_path: Path | None = None, *, timeout: float = 3.0):
+        configured = os.environ.get("ASCENTO_SUPERVISOR_SOCKET")
+        self.socket_path = Path(configured) if configured else (socket_path or DEFAULT_SOCKET)
+        self.timeout = timeout
+
+    def _request(self, operation: str, **values: Any) -> dict[str, Any]:
+        payload = json.dumps({"op": operation, **values}, separators=(",", ":")) + "\n"
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+                connection.settimeout(self.timeout)
+                connection.connect(str(self.socket_path))
+                connection.sendall(payload.encode("utf-8"))
+                chunks = bytearray()
+                while len(chunks) <= 1_048_576:
+                    chunk = connection.recv(65_536)
+                    if not chunk:
+                        break
+                    chunks.extend(chunk)
+                    if b"\n" in chunk:
+                        break
+        except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError) as error:
+            raise SupervisorUnavailable(
+                f"host supervisor is unavailable at {self.socket_path}: {error}"
+            ) from error
+
+        try:
+            response = json.loads(bytes(chunks).split(b"\n", 1)[0].decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise SupervisorUnavailable("host supervisor returned an invalid response") from error
+        if not isinstance(response, dict):
+            raise SupervisorUnavailable("host supervisor returned an invalid response")
+        if not response.get("ok"):
+            raise SupervisorRejected(str(response.get("error") or "supervisor rejected request"))
+        result = response.get("result")
+        return result if isinstance(result, dict) else {}
+
+    def status(self, *, refresh: bool = False) -> dict[str, Any]:
+        return self._request("status", refresh=refresh)
+
+    def update(self) -> dict[str, Any]:
+        return self._request("update")

--- a/docker/compose.tailscale.yaml
+++ b/docker/compose.tailscale.yaml
@@ -8,6 +8,9 @@ services:
       TS_HOSTNAME: ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard}
       TS_STATE_DIR: /var/lib/tailscale
       TS_USERSPACE: "false"
+      # OAuth client secrets require an advertised tag, for example:
+      # ASCENTO_TAILSCALE_EXTRA_ARGS=--advertise-tags=tag:ascento
+      TS_EXTRA_ARGS: ${ASCENTO_TAILSCALE_EXTRA_ARGS:-}
     volumes:
       - tailscale-dashboard-state:/var/lib/tailscale
     devices:

--- a/docker/compose.tailscale.yaml
+++ b/docker/compose.tailscale.yaml
@@ -1,0 +1,33 @@
+services:
+  tailscale-dashboard:
+    image: ${ASCENTO_TAILSCALE_IMAGE:-tailscale/tailscale:v1.102.2}
+    hostname: ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard}
+    environment:
+      TS_AUTHKEY: ${TS_AUTHKEY:-}
+      TS_AUTH_ONCE: "true"
+      TS_HOSTNAME: ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard}
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_USERSPACE: "false"
+    volumes:
+      - tailscale-dashboard-state:/var/lib/tailscale
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    ports:
+      # Preserve workstation-local access while the Dashboard shares this
+      # container's network namespace. Tailnet peers connect to port 8000 on
+      # the Tailscale address / MagicDNS name instead.
+      - "127.0.0.1:${ASCENTO_DASHBOARD_PORT:-8000}:8000"
+    restart: unless-stopped
+
+  dashboard:
+    network_mode: service:tailscale-dashboard
+    ports: !reset []
+    depends_on:
+      tailscale-dashboard:
+        condition: service_started
+
+volumes:
+  tailscale-dashboard-state:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -37,9 +37,13 @@ services:
       - ../checkpoints:/workspace/checkpoints:ro
       - ../captures:/workspace/captures:ro
       - ../evaluations:/workspace/evaluations:ro
+      # This is the only host-control surface exposed to the web container.
+      # It is a fixed-operation Unix socket, not Docker's control socket.
+      - ../.maintenance/supervisor:/run/ascento-supervisor
     environment:
       MUJOCO_GL: ${ASCENTO_MUJOCO_GL:-disable}
       ASCENTO_ARTIFACT_ROOT: /workspace/logs/rsl_rl
       ASCENTO_REPOSITORY_COMMIT: ${ASCENTO_REPOSITORY_COMMIT:-unknown}
       ASCENTO_REPOSITORY_BRANCH: ${ASCENTO_REPOSITORY_BRANCH:-unknown}
+      ASCENTO_SUPERVISOR_SOCKET: /run/ascento-supervisor/supervisor.sock
     restart: unless-stopped

--- a/scripts/host_supervisor.py
+++ b/scripts/host_supervisor.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Minimal host-side control boundary for repository status and maintenance updates.
+
+The dashboard container talks to this process over a Unix-domain socket.  The
+protocol deliberately exposes only a small fixed command set; it is not a shell
+proxy and never accepts arbitrary commands, paths, branches, or Docker actions.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socketserver
+import subprocess
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ACTIVE_RUN_STATES = {"starting", "running", "stopping"}
+STATUS_CACHE_SECONDS = 30.0
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return values
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+class HostSupervisor:
+    """Fixed-purpose host controller used by the dashboard system API."""
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root.expanduser().resolve()
+        self.maintenance_root = self.repo_root / ".maintenance"
+        self.update_state_path = self.maintenance_root / "update-state.json"
+        self.update_log_path = self.maintenance_root / "update.log"
+        self.tailscale_marker = self.maintenance_root / "tailscale-enabled"
+        self._update_lock = threading.Lock()
+        self._status_lock = threading.Lock()
+        self._status_cache: tuple[float, dict[str, Any]] | None = None
+
+    def _run(
+        self,
+        command: list[str],
+        *,
+        timeout: float = 10.0,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            command,
+            cwd=self.repo_root,
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def _git(self, *args: str, timeout: float = 10.0, check: bool = True) -> str:
+        result = self._run(["git", *args], timeout=timeout, check=check)
+        return result.stdout.strip()
+
+    def active_runs(self) -> list[dict[str, str]]:
+        root = self.repo_root / "logs" / "rsl_rl"
+        if not root.is_dir():
+            return []
+        active: list[dict[str, str]] = []
+        for path in root.rglob("run_status.json"):
+            status = _load_json(path)
+            state = str(status.get("state") or "")
+            if state not in ACTIVE_RUN_STATES:
+                continue
+            run_dir = path.parent
+            metadata = _load_json(run_dir / "run_metadata.json")
+            active.append(
+                {
+                    "name": str(metadata.get("display_name") or run_dir.name),
+                    "state": state,
+                    "path": run_dir.relative_to(root).as_posix(),
+                }
+            )
+        return active
+
+    def update_state(self) -> dict[str, Any]:
+        state = _load_json(self.update_state_path)
+        if not state:
+            return {"status": "idle"}
+        if state.get("status") == "running" and isinstance(state.get("pid"), int):
+            try:
+                os.kill(int(state["pid"]), 0)
+            except ProcessLookupError:
+                # A supervisor crash can lose the waiter that records the final
+                # exit code. Do not claim success when the outcome is unknown.
+                state = {
+                    **state,
+                    "status": "unknown",
+                    "finished_at": _now(),
+                    "message": "update process exited while supervisor was not tracking it",
+                }
+                _write_json(self.update_state_path, state)
+            except (PermissionError, OSError):
+                pass
+        return state
+
+    def _tailscale_status(self) -> dict[str, Any]:
+        enabled = self.tailscale_marker.is_file()
+        result: dict[str, Any] = {
+            "enabled": enabled,
+            "connected": False,
+            "dns_name": None,
+            "ips": [],
+            "url": None,
+        }
+        if not enabled:
+            return result
+        try:
+            container_id = self._run(
+                [
+                    "docker",
+                    "ps",
+                    "--filter",
+                    "label=com.docker.compose.service=tailscale-dashboard",
+                    "--format",
+                    "{{.ID}}",
+                ],
+                timeout=4.0,
+            ).stdout.splitlines()[0].strip()
+            raw = self._run(
+                ["docker", "exec", container_id, "tailscale", "status", "--json"],
+                timeout=5.0,
+            ).stdout
+            status = json.loads(raw)
+            self_status = status.get("Self") if isinstance(status.get("Self"), dict) else {}
+            dns_name = str(self_status.get("DNSName") or "").rstrip(".") or None
+            ips = self_status.get("TailscaleIPs") if isinstance(self_status.get("TailscaleIPs"), list) else []
+            connected = str(status.get("BackendState") or "").lower() == "running" or bool(ips)
+            port = _env_file(self.maintenance_root / "compose.env").get(
+                "ASCENTO_DASHBOARD_PORT", "8000"
+            )
+            result.update(
+                {
+                    "connected": connected,
+                    "dns_name": dns_name,
+                    "ips": [str(value) for value in ips],
+                    "url": f"http://{dns_name}:{port}" if dns_name else None,
+                }
+            )
+        except (IndexError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as error:
+            result["error"] = str(error)
+        return result
+
+    def repository_status(self, *, refresh: bool = False) -> dict[str, Any]:
+        with self._status_lock:
+            if not refresh and self._status_cache is not None:
+                cached_at, cached = self._status_cache
+                if time.monotonic() - cached_at < STATUS_CACHE_SECONDS:
+                    return cached
+
+            remote_error: str | None = None
+            try:
+                # Fetching the remote ref lets us calculate ahead/behind and list
+                # incoming commits without modifying the checked-out files.
+                self._git("fetch", "--quiet", "--prune", "origin", "main", timeout=30.0)
+            except (OSError, subprocess.SubprocessError) as error:
+                remote_error = str(error)
+
+            try:
+                local_commit = self._git("rev-parse", "HEAD")
+                branch = self._git("branch", "--show-current") or None
+                dirty = bool(self._git("status", "--porcelain", "--untracked-files=no"))
+            except (OSError, subprocess.SubprocessError) as error:
+                return {
+                    "ok": False,
+                    "error": f"cannot inspect local repository: {error}",
+                    "update": self.update_state(),
+                    "tailscale": self._tailscale_status(),
+                }
+
+            remote_commit: str | None = None
+            ahead = behind = None
+            incoming: list[dict[str, str]] = []
+            try:
+                remote_commit = self._git("rev-parse", "origin/main")
+                counts = self._git("rev-list", "--left-right", "--count", "HEAD...origin/main")
+                left, right = counts.split()
+                ahead, behind = int(left), int(right)
+                log_output = self._git(
+                    "log",
+                    "--max-count=8",
+                    "--format=%H%x09%s",
+                    "HEAD..origin/main",
+                )
+                for line in log_output.splitlines():
+                    if "\t" in line:
+                        commit, subject = line.split("\t", 1)
+                        incoming.append({"commit": commit, "subject": subject})
+            except (OSError, subprocess.SubprocessError, ValueError) as error:
+                remote_error = remote_error or str(error)
+
+            active = self.active_runs()
+            update = self.update_state()
+            update_running = update.get("status") == "running"
+            blockers: list[str] = []
+            if branch != "main":
+                blockers.append("checkout is not on main")
+            if dirty:
+                blockers.append("tracked files have local modifications")
+            if isinstance(ahead, int) and ahead > 0:
+                blockers.append("checkout has local-only commits")
+            if active:
+                blockers.append("one or more training runs are active")
+            if update_running:
+                blockers.append("an update is already running")
+            if remote_error:
+                blockers.append("remote repository status is unavailable")
+
+            update_available = bool(isinstance(behind, int) and behind > 0)
+            result = {
+                "ok": True,
+                "checked_at": _now(),
+                "repository": {
+                    "branch": branch,
+                    "local_commit": local_commit,
+                    "remote_branch": "main",
+                    "remote_commit": remote_commit,
+                    "dirty": dirty,
+                    "ahead_by": ahead,
+                    "behind_by": behind,
+                    "update_available": update_available,
+                    "incoming_commits": incoming,
+                    "remote_error": remote_error,
+                },
+                "active_runs": active,
+                "update": update,
+                "can_update": update_available and not blockers,
+                "update_blockers": blockers,
+                "tailscale": self._tailscale_status(),
+            }
+            self._status_cache = (time.monotonic(), result)
+            return result
+
+    def _compute_backend(self) -> str:
+        state = _load_json(self.maintenance_root / "repository-version.json")
+        compute = str(state.get("compute") or "auto")
+        return compute if compute in {"auto", "cpu", "cu128"} else "auto"
+
+    def start_update(self) -> dict[str, Any]:
+        with self._update_lock:
+            status = self.repository_status(refresh=True)
+            if not status.get("can_update"):
+                blockers = status.get("update_blockers") or ["update is not currently allowed"]
+                raise RuntimeError("; ".join(str(value) for value in blockers))
+
+            repository = status["repository"]
+            command = [
+                "bash",
+                str(self.repo_root / "scripts" / "maintain.sh"),
+                "--install-dir",
+                str(self.repo_root),
+                "--branch",
+                "main",
+                "--compute",
+                self._compute_backend(),
+            ]
+            self.maintenance_root.mkdir(parents=True, exist_ok=True)
+            log = self.update_log_path.open("a", encoding="utf-8", buffering=1)
+            log.write(f"\n[{_now()}] dashboard-requested update\n")
+            process = subprocess.Popen(
+                command,
+                cwd=self.repo_root,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+                start_new_session=True,
+            )
+            state = {
+                "status": "running",
+                "pid": process.pid,
+                "started_at": _now(),
+                "from_commit": repository.get("local_commit"),
+                "target_commit": repository.get("remote_commit"),
+                "log_path": str(self.update_log_path),
+            }
+            _write_json(self.update_state_path, state)
+            self._status_cache = None
+
+            def wait_for_update() -> None:
+                return_code = process.wait()
+                finished = {
+                    **state,
+                    "status": "success" if return_code == 0 else "error",
+                    "return_code": return_code,
+                    "finished_at": _now(),
+                }
+                _write_json(self.update_state_path, finished)
+                try:
+                    log.write(f"[{_now()}] update exited with code {return_code}\n")
+                finally:
+                    log.close()
+                with self._status_lock:
+                    self._status_cache = None
+
+            threading.Thread(target=wait_for_update, daemon=True, name="ascento-update-waiter").start()
+            return state
+
+    def dispatch(self, request: dict[str, Any]) -> dict[str, Any]:
+        operation = request.get("op")
+        if operation == "status":
+            return {"ok": True, "result": self.repository_status(refresh=bool(request.get("refresh")))}
+        if operation == "update":
+            try:
+                return {"ok": True, "result": self.start_update()}
+            except RuntimeError as error:
+                return {"ok": False, "error": str(error), "code": "update_blocked"}
+        return {"ok": False, "error": "unsupported supervisor operation", "code": "unsupported"}
+
+
+class _ThreadingUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class _Handler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        raw = self.rfile.readline(65_537)
+        if not raw or len(raw) > 65_536:
+            return
+        try:
+            request = json.loads(raw.decode("utf-8"))
+            if not isinstance(request, dict):
+                raise ValueError("request must be an object")
+            response = self.server.supervisor.dispatch(request)  # type: ignore[attr-defined]
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            response = {"ok": False, "error": str(error), "code": "bad_request"}
+        self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
+
+
+def serve(repo_root: Path, socket_path: Path) -> None:
+    supervisor = HostSupervisor(repo_root)
+    socket_path = socket_path.expanduser().resolve()
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    server = _ThreadingUnixServer(str(socket_path), _Handler)
+    server.supervisor = supervisor  # type: ignore[attr-defined]
+    os.chmod(socket_path, 0o660)
+    try:
+        server.serve_forever(poll_interval=0.5)
+    finally:
+        server.server_close()
+        try:
+            socket_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ascento host maintenance supervisor")
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--socket", type=Path, required=True)
+    args = parser.parse_args()
+    serve(args.repo, args.socket)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_supervisor.sh
+++ b/scripts/install_supervisor.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOCKET_DIR="$REPO_ROOT/.maintenance/supervisor"
+SOCKET_PATH="$SOCKET_DIR/supervisor.sock"
+PYTHON_BIN="${ASCENTO_SUPERVISOR_PYTHON:-$(command -v python3 || true)}"
+SERVICE_NAME="ascento-supervisor.service"
+
+usage() {
+  cat <<EOF
+Usage: scripts/install_supervisor.sh
+
+Install the Ascento host supervisor as a boot-persistent systemd service that
+runs as the current user. The service exposes only its Unix socket to the
+Dashboard container; Docker's control socket is never mounted into the Dashboard.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+[[ $# -eq 0 ]] || { usage >&2; exit 2; }
+
+[[ "$(uname -s)" == "Linux" ]] || { echo "ERROR: supervisor installation requires Linux/WSL2" >&2; exit 1; }
+[[ -n "$PYTHON_BIN" ]] || { echo "ERROR: python3 is required" >&2; exit 1; }
+mkdir -p "$SOCKET_DIR"
+chmod 700 "$SOCKET_DIR"
+
+if ! command -v systemctl >/dev/null 2>&1 || [[ ! -d /run/systemd/system ]]; then
+  echo "ERROR: systemd is required for the boot-persistent host supervisor." >&2
+  echo "On WSL2, enable systemd in /etc/wsl.conf and restart WSL, then rerun this script." >&2
+  exit 1
+fi
+
+SUDO=()
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  command -v sudo >/dev/null 2>&1 || { echo "ERROR: sudo is required to install the system service" >&2; exit 1; }
+  SUDO=(sudo)
+fi
+
+RUN_USER="${SUDO_USER:-${USER:-$(id -un)}}"
+RUN_GROUP="$(id -gn "$RUN_USER")"
+UNIT_PATH="/etc/systemd/system/$SERVICE_NAME"
+DOCKER_GROUP_LINE=""
+if getent group docker >/dev/null 2>&1; then
+  DOCKER_GROUP_LINE="SupplementaryGroups=docker"
+  if ! id -nG "$RUN_USER" | tr ' ' '\n' | grep -qx docker; then
+    echo "WARNING: $RUN_USER is not currently in the docker group."
+    echo "         The supervisor can report Git status, but maintenance Docker rebuilds may fail."
+  fi
+fi
+
+TMP_UNIT="$(mktemp)"
+trap 'rm -f "$TMP_UNIT"' EXIT
+cat >"$TMP_UNIT" <<EOF
+[Unit]
+Description=Ascento host maintenance supervisor
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$RUN_USER
+Group=$RUN_GROUP
+$DOCKER_GROUP_LINE
+WorkingDirectory=$REPO_ROOT
+Environment=HOME=$(getent passwd "$RUN_USER" | cut -d: -f6)
+ExecStart=$PYTHON_BIN "$REPO_ROOT/scripts/host_supervisor.py" --repo "$REPO_ROOT" --socket "$SOCKET_PATH"
+Restart=on-failure
+RestartSec=2
+NoNewPrivileges=true
+PrivateTmp=true
+UMask=0007
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+"${SUDO[@]}" install -m 0644 "$TMP_UNIT" "$UNIT_PATH"
+"${SUDO[@]}" systemctl daemon-reload
+"${SUDO[@]}" systemctl enable --now "$SERVICE_NAME"
+
+for _ in {1..30}; do
+  [[ -S "$SOCKET_PATH" ]] && break
+  sleep 0.2
+done
+if [[ ! -S "$SOCKET_PATH" ]]; then
+  echo "ERROR: supervisor socket did not appear: $SOCKET_PATH" >&2
+  "${SUDO[@]}" systemctl status "$SERVICE_NAME" --no-pager || true
+  exit 1
+fi
+
+echo "Host supervisor installed and running."
+echo "Service: $SERVICE_NAME"
+echo "Socket:  $SOCKET_PATH"
+echo "The Dashboard receives only this restricted socket, never /var/run/docker.sock."

--- a/scripts/install_supervisor.sh
+++ b/scripts/install_supervisor.sh
@@ -45,11 +45,10 @@ RUN_GROUP="$(id -gn "$RUN_USER")"
 UNIT_PATH="/etc/systemd/system/$SERVICE_NAME"
 DOCKER_GROUP_LINE=""
 if getent group docker >/dev/null 2>&1; then
+  # The process itself runs as the workstation user. This supplemental group is
+  # the only extra host capability it receives and is required for maintain.sh
+  # to rebuild/restart the project's Compose stack.
   DOCKER_GROUP_LINE="SupplementaryGroups=docker"
-  if ! id -nG "$RUN_USER" | tr ' ' '\n' | grep -qx docker; then
-    echo "WARNING: $RUN_USER is not currently in the docker group."
-    echo "         The supervisor can report Git status, but maintenance Docker rebuilds may fail."
-  fi
 fi
 
 TMP_UNIT="$(mktemp)"

--- a/scripts/install_supervisor.sh
+++ b/scripts/install_supervisor.sh
@@ -92,6 +92,10 @@ if [[ ! -S "$SOCKET_PATH" ]]; then
   exit 1
 fi
 
+printf 'installed_at=%s\nservice=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SERVICE_NAME" \
+  >"$REPO_ROOT/.maintenance/supervisor-installed"
+chmod 600 "$REPO_ROOT/.maintenance/supervisor-installed"
+
 echo "Host supervisor installed and running."
 echo "Service: $SERVICE_NAME"
 echo "Socket:  $SOCKET_PATH"

--- a/scripts/maintain.sh
+++ b/scripts/maintain.sh
@@ -303,7 +303,8 @@ build_frontend() {
 
 write_maintenance_state() {
   local state="$INSTALL_DIR/.maintenance"
-  mkdir -p "$state"
+  mkdir -p "$state" "$state/supervisor"
+  chmod 700 "$state/supervisor"
   local commit branch
   commit="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
   branch="$(git -C "$INSTALL_DIR" branch --show-current)"
@@ -323,24 +324,32 @@ ASCENTO_DASHBOARD_PORT=${ASCENTO_DASHBOARD_PORT:-8000}
 EOF
 }
 
+compose_files() {
+  COMPOSE_FILES=(-f "$INSTALL_DIR/docker/compose.yaml")
+  [[ "$COMPUTE" == "cu128" ]] && COMPOSE_FILES+=(-f "$INSTALL_DIR/docker/compose.gpu.yaml")
+  if [[ -f "$INSTALL_DIR/.maintenance/tailscale-enabled" ]]; then
+    COMPOSE_FILES+=(-f "$INSTALL_DIR/docker/compose.tailscale.yaml")
+  fi
+}
+
 build_containers() {
   (( BUILD_DOCKER )) || return 0
   log "Rebuilding Docker image from the current lockfiles"
   local envfile="$INSTALL_DIR/.maintenance/compose.env"
-  local files=(-f "$INSTALL_DIR/docker/compose.yaml")
-  [[ "$COMPUTE" == "cu128" ]] && files+=(-f "$INSTALL_DIR/docker/compose.gpu.yaml")
-  docker_exec compose --env-file "$envfile" "${files[@]}" down --remove-orphans || true
-  docker_exec compose --env-file "$envfile" "${files[@]}" build --pull --no-cache
-  if (( START_DASHBOARD )); then docker_exec compose --env-file "$envfile" "${files[@]}" up -d dashboard; fi
+  compose_files
+  docker_exec compose --env-file "$envfile" "${COMPOSE_FILES[@]}" down --remove-orphans || true
+  docker_exec compose --env-file "$envfile" "${COMPOSE_FILES[@]}" build --pull --no-cache
+  if (( START_DASHBOARD )); then
+    docker_exec compose --env-file "$envfile" "${COMPOSE_FILES[@]}" up -d dashboard
+  fi
 }
 
 verify_installation() {
   log "Running maintenance verification"
   (cd "$INSTALL_DIR" && .venv/bin/python -m pytest -q tests_dashboard)
   if (( BUILD_DOCKER )); then
-    local files=(-f "$INSTALL_DIR/docker/compose.yaml")
-    [[ "$COMPUTE" == "cu128" ]] && files+=(-f "$INSTALL_DIR/docker/compose.gpu.yaml")
-    docker_exec compose --env-file "$INSTALL_DIR/.maintenance/compose.env" "${files[@]}" config >/dev/null
+    compose_files
+    docker_exec compose --env-file "$INSTALL_DIR/.maintenance/compose.env" "${COMPOSE_FILES[@]}" config >/dev/null
   fi
 }
 
@@ -363,4 +372,9 @@ log "Maintenance complete"
 echo "Checkout: $INSTALL_DIR"
 echo "Repository: $(git -C "$INSTALL_DIR" rev-parse --short HEAD) ($BRANCH)"
 echo "Compute backend: $COMPUTE"
-if (( BUILD_DOCKER && START_DASHBOARD )); then echo "Dashboard: http://127.0.0.1:${ASCENTO_DASHBOARD_PORT:-8000}"; fi
+if (( BUILD_DOCKER && START_DASHBOARD )); then
+  echo "Dashboard: http://127.0.0.1:${ASCENTO_DASHBOARD_PORT:-8000}"
+  if [[ -f "$INSTALL_DIR/.maintenance/tailscale-enabled" ]]; then
+    echo "Tailnet dashboard ingress: enabled (persistent sidecar state retained)"
+  fi
+fi

--- a/scripts/setup_tailscale.sh
+++ b/scripts/setup_tailscale.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAINTENANCE="$REPO_ROOT/.maintenance"
+ENVFILE="$MAINTENANCE/compose.env"
+MARKER="$MAINTENANCE/tailscale-enabled"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/setup_tailscale.sh
+
+Enroll the Dashboard ingress sidecar in your Tailscale tailnet. Supply the auth
+credential through TS_AUTHKEY or enter it at the hidden prompt. The credential
+is used only for initial enrollment and is removed from the recreated Docker
+container immediately after state has been persisted in the named volume.
+
+Optional environment variables:
+  ASCENTO_TAILSCALE_HOSTNAME   Tailnet hostname (default: ascento-dashboard)
+  TS_AUTHKEY                   Tailscale auth key or OAuth client secret
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+[[ $# -eq 0 ]] || { usage >&2; exit 2; }
+[[ "$(uname -s)" == "Linux" ]] || { echo "ERROR: Tailscale Docker sidecar requires Linux/WSL2" >&2; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "ERROR: Docker is required" >&2; exit 1; }
+docker compose version >/dev/null 2>&1 || { echo "ERROR: Docker Compose plugin is required" >&2; exit 1; }
+[[ -f "$ENVFILE" ]] || {
+  echo "ERROR: $ENVFILE does not exist. Run scripts/maintain.sh once first." >&2
+  exit 1
+}
+[[ -e /dev/net/tun ]] || {
+  echo "ERROR: /dev/net/tun is unavailable. Tailscale kernel networking cannot start." >&2
+  exit 1
+}
+
+AUTH_KEY="${TS_AUTHKEY:-}"
+if [[ -z "$AUTH_KEY" ]]; then
+  read -rsp "Tailscale auth key / OAuth client secret: " AUTH_KEY
+  echo
+fi
+[[ -n "$AUTH_KEY" ]] || { echo "ERROR: no Tailscale credential supplied" >&2; exit 1; }
+
+COMPUTE="$(awk -F= '$1 == "ASCENTO_COMPUTE_EXTRA" {print $2}' "$ENVFILE" | tail -n1)"
+FILES=(-f "$REPO_ROOT/docker/compose.yaml")
+[[ "$COMPUTE" == "cu128" ]] && FILES+=(-f "$REPO_ROOT/docker/compose.gpu.yaml")
+FILES+=(-f "$REPO_ROOT/docker/compose.tailscale.yaml")
+
+compose() {
+  docker compose --env-file "$ENVFILE" "${FILES[@]}" "$@"
+}
+
+mkdir -p "$MAINTENANCE"
+echo "Enrolling ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard} in the tailnet..."
+TS_AUTHKEY="$AUTH_KEY" compose up -d tailscale-dashboard dashboard
+
+connected=0
+for _ in {1..60}; do
+  if compose exec -T tailscale-dashboard tailscale status --json >/dev/null 2>&1; then
+    connected=1
+    break
+  fi
+  sleep 0.5
+done
+if (( ! connected )); then
+  echo "ERROR: Tailscale sidecar did not become ready." >&2
+  compose logs --tail=100 tailscale-dashboard >&2 || true
+  exit 1
+fi
+
+# Recreate without TS_AUTHKEY so the secret is no longer present in Docker's
+# inspectable container environment. Persistent Tailscale state keeps the node
+# enrolled and TS_AUTH_ONCE prevents unnecessary reauthentication.
+unset TS_AUTHKEY
+AUTH_KEY=""
+compose up -d --force-recreate tailscale-dashboard dashboard
+
+connected=0
+for _ in {1..60}; do
+  if compose exec -T tailscale-dashboard tailscale status --json >/dev/null 2>&1; then
+    connected=1
+    break
+  fi
+  sleep 0.5
+done
+if (( ! connected )); then
+  echo "ERROR: Tailscale failed to reconnect from persisted state." >&2
+  compose logs --tail=100 tailscale-dashboard >&2 || true
+  exit 1
+fi
+
+printf 'enabled_at=%s\nhostname=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  "${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard}" >"$MARKER"
+chmod 600 "$MARKER"
+
+STATUS_JSON="$(compose exec -T tailscale-dashboard tailscale status --json)"
+DNS_NAME="$(printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("Self") or {}).get("DNSName", "").rstrip("."))')"
+DASHBOARD_PORT="$(awk -F= '$1 == "ASCENTO_DASHBOARD_PORT" {print $2}' "$ENVFILE" | tail -n1)"
+DASHBOARD_PORT="${DASHBOARD_PORT:-8000}"
+
+echo "Tailnet enrollment complete."
+if [[ -n "$DNS_NAME" ]]; then
+  echo "Remote Dashboard: http://$DNS_NAME:$DASHBOARD_PORT"
+else
+  echo "Use the Tailscale IP shown by: docker compose ... exec tailscale-dashboard tailscale status"
+fi
+echo "Local Dashboard:  http://127.0.0.1:$DASHBOARD_PORT"
+echo "Only the Dashboard network namespace is attached to the tailnet; the training service is not exposed."

--- a/scripts/setup_tailscale.sh
+++ b/scripts/setup_tailscale.sh
@@ -28,6 +28,7 @@ fi
 [[ $# -eq 0 ]] || { usage >&2; exit 2; }
 [[ "$(uname -s)" == "Linux" ]] || { echo "ERROR: Tailscale Docker sidecar requires Linux/WSL2" >&2; exit 1; }
 command -v docker >/dev/null 2>&1 || { echo "ERROR: Docker is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is required" >&2; exit 1; }
 docker compose version >/dev/null 2>&1 || { echo "ERROR: Docker Compose plugin is required" >&2; exit 1; }
 [[ -f "$ENVFILE" ]] || {
   echo "ERROR: $ENVFILE does not exist. Run scripts/maintain.sh once first." >&2
@@ -38,6 +39,27 @@ docker compose version >/dev/null 2>&1 || { echo "ERROR: Docker Compose plugin i
   exit 1
 }
 
+ACTIVE_RUNS="$(python3 - "$REPO_ROOT/logs/rsl_rl" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+active = []
+if root.is_dir():
+    for path in root.rglob('run_status.json'):
+        try:
+            value = json.loads(path.read_text(encoding='utf-8'))
+        except Exception:
+            continue
+        if value.get('state') in {'starting', 'running', 'stopping'}:
+            active.append(str(path.parent.relative_to(root)))
+print('\n'.join(active))
+PY
+)"
+if [[ -n "$ACTIVE_RUNS" ]]; then
+  echo "ERROR: Tailnet enrollment recreates the Dashboard and is blocked while runs are active:" >&2
+  printf '  %s\n' "$ACTIVE_RUNS" >&2
+  exit 1
+fi
+
 AUTH_KEY="${TS_AUTHKEY:-}"
 if [[ -z "$AUTH_KEY" ]]; then
   read -rsp "Tailscale auth key / OAuth client secret: " AUTH_KEY
@@ -46,9 +68,9 @@ fi
 [[ -n "$AUTH_KEY" ]] || { echo "ERROR: no Tailscale credential supplied" >&2; exit 1; }
 
 COMPUTE="$(awk -F= '$1 == "ASCENTO_COMPUTE_EXTRA" {print $2}' "$ENVFILE" | tail -n1)"
-FILES=(-f "$REPO_ROOT/docker/compose.yaml")
-[[ "$COMPUTE" == "cu128" ]] && FILES+=(-f "$REPO_ROOT/docker/compose.gpu.yaml")
-FILES+=(-f "$REPO_ROOT/docker/compose.tailscale.yaml")
+BASE_FILES=(-f "$REPO_ROOT/docker/compose.yaml")
+[[ "$COMPUTE" == "cu128" ]] && BASE_FILES+=(-f "$REPO_ROOT/docker/compose.gpu.yaml")
+FILES=("${BASE_FILES[@]}" -f "$REPO_ROOT/docker/compose.tailscale.yaml")
 
 compose() {
   docker compose --env-file "$ENVFILE" "${FILES[@]}" "$@"
@@ -56,6 +78,9 @@ compose() {
 
 mkdir -p "$MAINTENANCE"
 echo "Enrolling ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard} in the tailnet..."
+# Release the local 127.0.0.1 dashboard port before the sidecar takes ownership
+# of that same port in the shared network namespace.
+docker compose --env-file "$ENVFILE" "${BASE_FILES[@]}" stop dashboard >/dev/null 2>&1 || true
 TS_AUTHKEY="$AUTH_KEY" compose up -d tailscale-dashboard dashboard
 
 connected=0
@@ -106,7 +131,7 @@ echo "Tailnet enrollment complete."
 if [[ -n "$DNS_NAME" ]]; then
   echo "Remote Dashboard: http://$DNS_NAME:$DASHBOARD_PORT"
 else
-  echo "Use the Tailscale IP shown by: docker compose ... exec tailscale-dashboard tailscale status"
+  echo "Use the Tailscale IP shown by the tailscale-dashboard service."
 fi
 echo "Local Dashboard:  http://127.0.0.1:$DASHBOARD_PORT"
-echo "Only the Dashboard network namespace is attached to the tailnet; the training service is not exposed."
+echo "Only the Dashboard service identity is exposed to the tailnet; the ascento-mjlab service remains private."

--- a/scripts/setup_tailscale.sh
+++ b/scripts/setup_tailscale.sh
@@ -16,8 +16,11 @@ is used only for initial enrollment and is removed from the recreated Docker
 container immediately after state has been persisted in the named volume.
 
 Optional environment variables:
-  ASCENTO_TAILSCALE_HOSTNAME   Tailnet hostname (default: ascento-dashboard)
-  TS_AUTHKEY                   Tailscale auth key or OAuth client secret
+  ASCENTO_TAILSCALE_HOSTNAME     Tailnet hostname (default: ascento-dashboard)
+  ASCENTO_TAILSCALE_EXTRA_ARGS   Additional tailscaled login args. Required for
+                                 OAuth client secrets, e.g.
+                                 --advertise-tags=tag:ascento
+  TS_AUTHKEY                     Tailscale auth key or OAuth client secret
 EOF
 }
 

--- a/tests_dashboard/test_host_supervisor.py
+++ b/tests_dashboard/test_host_supervisor.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+from scripts.host_supervisor import HostSupervisor
+
+
+def test_repository_status_reports_remote_delta_and_incoming_commits(monkeypatch, tmp_path):
+    supervisor = HostSupervisor(tmp_path)
+
+    def fake_git(*args, **_kwargs):
+        if args[:4] == ("fetch", "--quiet", "--prune", "origin"):
+            return ""
+        if args == ("rev-parse", "HEAD"):
+            return "local123"
+        if args == ("branch", "--show-current"):
+            return "main"
+        if args == ("status", "--porcelain", "--untracked-files=no"):
+            return ""
+        if args == ("rev-parse", "origin/main"):
+            return "remote456"
+        if args == ("rev-list", "--left-right", "--count", "HEAD...origin/main"):
+            return "0\t2"
+        if args[:3] == ("log", "--max-count=8", "--format=%H%x09%s"):
+            return "remote456\tFix recovery gate\nremote455\tImprove dashboard"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(supervisor, "_git", fake_git)
+    monkeypatch.setattr(supervisor, "active_runs", lambda: [])
+    monkeypatch.setattr(supervisor, "update_state", lambda: {"status": "idle"})
+    monkeypatch.setattr(
+        supervisor,
+        "_tailscale_status",
+        lambda: {"enabled": True, "connected": True, "dns_name": "ascento.example.ts.net"},
+    )
+
+    status = supervisor.repository_status(refresh=True)
+
+    assert status["repository"]["local_commit"] == "local123"
+    assert status["repository"]["remote_commit"] == "remote456"
+    assert status["repository"]["behind_by"] == 2
+    assert status["repository"]["ahead_by"] == 0
+    assert status["repository"]["update_available"] is True
+    assert status["repository"]["incoming_commits"][0]["subject"] == "Fix recovery gate"
+    assert status["can_update"] is True
+    assert status["update_blockers"] == []
+
+
+def test_repository_update_is_blocked_by_active_training(monkeypatch, tmp_path):
+    supervisor = HostSupervisor(tmp_path)
+
+    def fake_git(*args, **_kwargs):
+        values = {
+            ("rev-parse", "HEAD"): "local123",
+            ("branch", "--show-current"): "main",
+            ("status", "--porcelain", "--untracked-files=no"): "",
+            ("rev-parse", "origin/main"): "remote456",
+            ("rev-list", "--left-right", "--count", "HEAD...origin/main"): "0 1",
+        }
+        if args[:4] == ("fetch", "--quiet", "--prune", "origin"):
+            return ""
+        if args[:3] == ("log", "--max-count=8", "--format=%H%x09%s"):
+            return "remote456\tUpdate"
+        return values[args]
+
+    monkeypatch.setattr(supervisor, "_git", fake_git)
+    monkeypatch.setattr(
+        supervisor,
+        "active_runs",
+        lambda: [{"name": "Recovery long run", "state": "running", "path": "run-a"}],
+    )
+    monkeypatch.setattr(supervisor, "update_state", lambda: {"status": "idle"})
+    monkeypatch.setattr(supervisor, "_tailscale_status", lambda: {"enabled": False, "connected": False})
+
+    status = supervisor.repository_status(refresh=True)
+
+    assert status["repository"]["update_available"] is True
+    assert status["can_update"] is False
+    assert "one or more training runs are active" in status["update_blockers"]
+
+
+def test_active_run_scan_reads_launcher_statuses(tmp_path):
+    root = tmp_path / "logs" / "rsl_rl"
+    active = root / "run-a"
+    finished = root / "run-b"
+    active.mkdir(parents=True)
+    finished.mkdir(parents=True)
+    (active / "run_status.json").write_text(
+        json.dumps({"state": "running"}), encoding="utf-8"
+    )
+    (active / "run_metadata.json").write_text(
+        json.dumps({"display_name": "Recovery validation"}), encoding="utf-8"
+    )
+    (finished / "run_status.json").write_text(
+        json.dumps({"state": "finished"}), encoding="utf-8"
+    )
+
+    runs = HostSupervisor(tmp_path).active_runs()
+
+    assert runs == [
+        {"name": "Recovery validation", "state": "running", "path": "run-a"}
+    ]
+
+
+def test_dispatch_exposes_only_status_and_update(monkeypatch, tmp_path):
+    supervisor = HostSupervisor(tmp_path)
+    monkeypatch.setattr(supervisor, "repository_status", lambda **_kwargs: {"can_update": False})
+
+    assert supervisor.dispatch({"op": "status"}) == {
+        "ok": True,
+        "result": {"can_update": False},
+    }
+    rejected = supervisor.dispatch({"op": "shell", "command": "rm -rf /"})
+    assert rejected["ok"] is False
+    assert rejected["code"] == "unsupported"

--- a/tests_dashboard/test_system_api.py
+++ b/tests_dashboard/test_system_api.py
@@ -13,6 +13,14 @@ def _load_app(monkeypatch, artifact_root):
     return importlib.reload(dashboard_app)
 
 
+class ControlRequest:
+    headers = {"x-ascento-control": "1"}
+
+
+class UnprotectedRequest:
+    headers = {}
+
+
 def test_system_status_surfaces_supervisor_repository_and_tailnet(monkeypatch, tmp_path):
     module = _load_app(monkeypatch, tmp_path)
 
@@ -42,7 +50,7 @@ def test_system_status_surfaces_supervisor_repository_and_tailnet(monkeypatch, t
     assert result["repository"]["behind_by"] == 2
     assert result["tailscale"]["connected"] is True
     assert result["can_update"] is True
-    assert module.system_update()["status"] == "running"
+    assert module.system_update(ControlRequest())["status"] == "running"
 
 
 def test_system_status_degrades_cleanly_when_supervisor_is_missing(monkeypatch, tmp_path):
@@ -61,6 +69,20 @@ def test_system_status_degrades_cleanly_when_supervisor_is_missing(monkeypatch, 
     assert "socket missing" in result["error"]
 
 
+def test_system_update_requires_control_header(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    class FakeSupervisor:
+        def update(self):
+            raise AssertionError("supervisor must not be called without control header")
+
+    module.SUPERVISOR = FakeSupervisor()
+    with pytest.raises(HTTPException) as error:
+        module.system_update(UnprotectedRequest())
+
+    assert error.value.status_code == 403
+
+
 def test_system_update_maps_supervisor_rejection_to_conflict(monkeypatch, tmp_path):
     module = _load_app(monkeypatch, tmp_path)
 
@@ -70,7 +92,7 @@ def test_system_update_maps_supervisor_rejection_to_conflict(monkeypatch, tmp_pa
 
     module.SUPERVISOR = BlockedSupervisor()
     with pytest.raises(HTTPException) as error:
-        module.system_update()
+        module.system_update(ControlRequest())
 
     assert error.value.status_code == 409
     assert "training runs" in error.value.detail
@@ -85,6 +107,6 @@ def test_system_update_maps_missing_supervisor_to_service_unavailable(monkeypatc
 
     module.SUPERVISOR = MissingSupervisor()
     with pytest.raises(HTTPException) as error:
-        module.system_update()
+        module.system_update(ControlRequest())
 
     assert error.value.status_code == 503

--- a/tests_dashboard/test_system_api.py
+++ b/tests_dashboard/test_system_api.py
@@ -1,0 +1,90 @@
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+from dashboard.supervisor_client import SupervisorRejected, SupervisorUnavailable
+
+
+def _load_app(monkeypatch, artifact_root):
+    monkeypatch.setenv("ASCENTO_ARTIFACT_ROOT", str(artifact_root))
+    import dashboard.app as dashboard_app
+
+    return importlib.reload(dashboard_app)
+
+
+def test_system_status_surfaces_supervisor_repository_and_tailnet(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    class FakeSupervisor:
+        def status(self, *, refresh=False):
+            assert refresh is True
+            return {
+                "repository": {"branch": "main", "behind_by": 2, "update_available": True},
+                "can_update": True,
+                "update_blockers": [],
+                "active_runs": [],
+                "update": {"status": "idle"},
+                "tailscale": {
+                    "enabled": True,
+                    "connected": True,
+                    "dns_name": "ascento-dashboard.example.ts.net",
+                },
+            }
+
+        def update(self):
+            return {"status": "running"}
+
+    module.SUPERVISOR = FakeSupervisor()
+    result = module.system_status(refresh=True)
+
+    assert result["connected"] is True
+    assert result["repository"]["behind_by"] == 2
+    assert result["tailscale"]["connected"] is True
+    assert result["can_update"] is True
+    assert module.system_update()["status"] == "running"
+
+
+def test_system_status_degrades_cleanly_when_supervisor_is_missing(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    class MissingSupervisor:
+        def status(self, *, refresh=False):
+            raise SupervisorUnavailable("socket missing")
+
+    module.SUPERVISOR = MissingSupervisor()
+    result = module.system_status()
+
+    assert result["connected"] is False
+    assert result["can_update"] is False
+    assert result["update"]["status"] == "unavailable"
+    assert "socket missing" in result["error"]
+
+
+def test_system_update_maps_supervisor_rejection_to_conflict(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    class BlockedSupervisor:
+        def update(self):
+            raise SupervisorRejected("one or more training runs are active")
+
+    module.SUPERVISOR = BlockedSupervisor()
+    with pytest.raises(HTTPException) as error:
+        module.system_update()
+
+    assert error.value.status_code == 409
+    assert "training runs" in error.value.detail
+
+
+def test_system_update_maps_missing_supervisor_to_service_unavailable(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+
+    class MissingSupervisor:
+        def update(self):
+            raise SupervisorUnavailable("not installed")
+
+    module.SUPERVISOR = MissingSupervisor()
+    with pytest.raises(HTTPException) as error:
+        module.system_update()
+
+    assert error.value.status_code == 503


### PR DESCRIPTION
## Summary

Add the second control-plane pass: a deliberately small host-side maintenance boundary, local-vs-remote Git/update workflow, a System page with an Update button, and private remote Dashboard access through a Tailscale Docker sidecar.

### Host supervisor / update boundary
- add `scripts/host_supervisor.py`, a stdlib-only host process with a fixed Unix-socket protocol;
- expose only `status` and `update` operations — no arbitrary shell, path, branch, or Docker command API;
- run it as the workstation user under a boot-persistent systemd unit installed by `scripts/install_supervisor.sh`;
- never mount `/var/run/docker.sock` into the Dashboard;
- report local commit/branch, `origin/main`, ahead/behind counts, dirty state, incoming commit subjects, active runs, update state, and Tailnet state;
- reject GUI updates while a run is starting/running/stopping, the checkout is dirty/not on main/ahead of main, the remote cannot be verified, or another update is active;
- invoke the existing `scripts/maintain.sh` in an independent process session so Dashboard/container restarts do not kill the update;
- require a custom `X-Ascento-Control` header for the privileged update endpoint to prevent simple cross-site browser requests.

### Dashboard / UI
- add `GET /api/system` and guarded `POST /api/system/update`;
- add a dedicated **System** page showing repository status, incoming commits, blockers, active runs, last/current update, supervisor health, and Tailnet address;
- add an **Update to latest main** button that is enabled only when the supervisor says the update is safe.

### Tailscale remote access
- add `docker/compose.tailscale.yaml` using the official Tailscale container as a sidecar;
- the Dashboard shares the sidecar's network namespace; the separate `ascento-mjlab` service is not joined to the Tailnet ingress;
- retain local access on `127.0.0.1:8000` while Tailnet peers can use the node's Tailscale IP / MagicDNS name on port 8000;
- use persistent Tailscale state so maintenance rebuilds reconnect automatically;
- add `scripts/setup_tailscale.sh` for one-time enrollment; the auth credential is used transiently, then the sidecar is recreated without it in the Docker environment;
- support auth keys and tagged OAuth enrollment via `ASCENTO_TAILSCALE_EXTRA_ARGS`;
- do not enable Funnel or public-internet exposure.

### Maintenance / validation
- teach `maintain.sh` to preserve the Tailscale overlay after enrollment;
- add supervisor, system API, update-guard, active-run, and restricted-operation tests;
- extend CI to syntax-check the new scripts and validate base, GPU, and Tailscale Compose configurations;
- document the one-time supervisor and Tailnet setup in the root and dashboard READMEs.

## Deployment note

Actual Tailnet enrollment still requires a private Tailscale auth credential on the workstation. After this is merged and pulled, run:

```bash
bash scripts/install_supervisor.sh
bash scripts/setup_tailscale.sh
```

The second command prompts for the credential without storing it in the repository.