### PR TITLE
Fix Tailscale enrollment readiness race

### DIFF
--- a/scripts/setup_tailscale.sh
+++ b/scripts/setup_tailscale.sh
@@ -79,6 +79,25 @@ compose() {
   docker compose --env-file "$ENVFILE" "${FILES[@]}" "$@"
 }
 
+tailscale_running() {
+  compose exec -T tailscale-dashboard tailscale status --json 2>/dev/null \
+    | python3 "$REPO_ROOT/scripts/tailscale_status.py" >/dev/null 2>&1
+}
+
+wait_for_tailscale_running() {
+  local phase="$1"
+  local attempts="${2:-120}"
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if tailscale_running; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "ERROR: Tailscale did not reach authenticated Running state during $phase." >&2
+  return 1
+}
+
 mkdir -p "$MAINTENANCE"
 echo "Enrolling ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard} in the tailnet..."
 # Release the local 127.0.0.1 dashboard port before the sidecar takes ownership
@@ -86,17 +105,11 @@ echo "Enrolling ${ASCENTO_TAILSCALE_HOSTNAME:-ascento-dashboard} in the tailnet.
 docker compose --env-file "$ENVFILE" "${BASE_FILES[@]}" stop dashboard >/dev/null 2>&1 || true
 TS_AUTHKEY="$AUTH_KEY" compose up -d tailscale-dashboard dashboard
 
-connected=0
-for _ in {1..60}; do
-  if compose exec -T tailscale-dashboard tailscale status --json >/dev/null 2>&1; then
-    connected=1
-    break
-  fi
-  sleep 0.5
-done
-if (( ! connected )); then
-  echo "ERROR: Tailscale sidecar did not become ready." >&2
-  compose logs --tail=100 tailscale-dashboard >&2 || true
+# `tailscale status --json` can succeed while containerboot is still in
+# NeedsLogin/Starting. Dropping the auth key at that point races persistence and
+# can leave the recreated sidecar repeatedly requesting interactive browser auth.
+if ! wait_for_tailscale_running "initial enrollment"; then
+  compose logs --tail=120 tailscale-dashboard >&2 || true
   exit 1
 fi
 
@@ -107,17 +120,8 @@ unset TS_AUTHKEY
 AUTH_KEY=""
 compose up -d --force-recreate tailscale-dashboard dashboard
 
-connected=0
-for _ in {1..60}; do
-  if compose exec -T tailscale-dashboard tailscale status --json >/dev/null 2>&1; then
-    connected=1
-    break
-  fi
-  sleep 0.5
-done
-if (( ! connected )); then
-  echo "ERROR: Tailscale failed to reconnect from persisted state." >&2
-  compose logs --tail=100 tailscale-dashboard >&2 || true
+if ! wait_for_tailscale_running "credential-free reconnect"; then
+  compose logs --tail=120 tailscale-dashboard >&2 || true
   exit 1
 fi
 

--- a/scripts/tailscale_status.py
+++ b/scripts/tailscale_status.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate that a Tailscale status snapshot represents a usable logged-in node."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def is_running(status: dict[str, Any]) -> bool:
+    """Return True only after containerboot has reached an authenticated Running state."""
+    if status.get("BackendState") != "Running":
+        return False
+    self_node = status.get("Self")
+    if not isinstance(self_node, dict):
+        return False
+    tailscale_ips = self_node.get("TailscaleIPs")
+    return isinstance(tailscale_ips, list) and bool(tailscale_ips)
+
+
+def main() -> int:
+    try:
+        status = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        return 2
+    if not isinstance(status, dict):
+        return 2
+    return 0 if is_running(status) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_dashboard/test_tailscale_status.py
+++ b/tests_dashboard/test_tailscale_status.py
@@ -1,0 +1,43 @@
+import json
+import subprocess
+import sys
+
+
+SCRIPT = "scripts/tailscale_status.py"
+
+
+def _run(payload):
+    return subprocess.run(
+        [sys.executable, SCRIPT],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    ).returncode
+
+
+def test_tailscale_status_rejects_needs_login_even_with_valid_json():
+    assert _run({"BackendState": "NeedsLogin", "Self": {"TailscaleIPs": []}}) == 1
+
+
+def test_tailscale_status_rejects_starting_state():
+    assert _run({"BackendState": "Starting", "Self": {"TailscaleIPs": ["100.64.0.1"]}}) == 1
+
+
+def test_tailscale_status_rejects_running_without_assigned_tailnet_ip():
+    assert _run({"BackendState": "Running", "Self": {"TailscaleIPs": []}}) == 1
+
+
+def test_tailscale_status_accepts_authenticated_running_node():
+    assert _run({"BackendState": "Running", "Self": {"TailscaleIPs": ["100.64.0.1"]}}) == 0
+
+
+def test_tailscale_status_rejects_invalid_json():
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        input="not-json",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary

Fix the Tailscale sidecar enrollment race observed after PR #86 was merged.

The setup script previously treated a successful `tailscale status --json` invocation as proof that the sidecar was ready. Tailscale can return valid status JSON while the backend is still `NeedsLogin` or `Starting`, so the script could remove `TS_AUTHKEY` and force-recreate the sidecar before authenticated state had been persisted. That leaves the replacement container falling back to interactive browser login and repeatedly restarting on the containerboot authentication timeout.

### Changes
- add a small stdlib-only Tailscale status validator;
- require `BackendState == "Running"` plus an assigned Tailscale IP before enrollment is considered complete;
- use that strict readiness gate both before removing the credential and after recreating the sidecar without it;
- extend the wait window from 30s to 60s and print explicit phase-specific errors;
- add regression tests for `NeedsLogin`, `Starting`, incomplete `Running`, valid `Running`, and invalid JSON.

### Runtime evidence
The supplied workstation log showed repeated auth URLs / one-minute `context deadline exceeded` restarts, followed eventually by `machineAuthorized=true` and `Starting -> Running`. This patch prevents setup from dropping the credential during those pre-Running states.
