### PR TITLE
Fix supervisor socket path on long WSL checkouts

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -57,8 +57,10 @@ bash scripts/install_supervisor.sh
 
 The installer creates a boot-persistent systemd service. The process runs as the
 workstation user, with Docker-group access only so `maintain.sh` can rebuild the
-project stack. The Dashboard receives only `.maintenance/supervisor/supervisor.sock`
-through a bind mount.
+project stack. systemd creates the short-lived `/run/ascento-supervisor` runtime
+directory, and the Dashboard receives only its `supervisor.sock` through a bind
+mount. Keeping the socket outside the checkout avoids Linux's 108-byte
+Unix-domain socket path limit on long WSL-mounted paths.
 
 The supervisor refuses a GUI-triggered update when:
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -39,7 +39,7 @@ services:
       - ../evaluations:/workspace/evaluations:ro
       # This is the only host-control surface exposed to the web container.
       # It is a fixed-operation Unix socket, not Docker's control socket.
-      - ../.maintenance/supervisor:/run/ascento-supervisor
+      - /run/ascento-supervisor:/run/ascento-supervisor
     environment:
       MUJOCO_GL: ${ASCENTO_MUJOCO_GL:-disable}
       ASCENTO_ARTIFACT_ROOT: /workspace/logs/rsl_rl

--- a/scripts/install_supervisor.sh
+++ b/scripts/install_supervisor.sh
@@ -2,7 +2,10 @@
 set -Eeuo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SOCKET_DIR="$REPO_ROOT/.maintenance/supervisor"
+# Keep this outside the checkout: Linux limits Unix-domain socket paths to
+# 108 bytes, which long WSL-mounted paths (for example, OneDrive checkouts)
+# can exceed.
+SOCKET_DIR="/run/ascento-supervisor"
 SOCKET_PATH="$SOCKET_DIR/supervisor.sock"
 PYTHON_BIN="${ASCENTO_SUPERVISOR_PYTHON:-$(command -v python3 || true)}"
 SERVICE_NAME="ascento-supervisor.service"
@@ -25,9 +28,6 @@ fi
 
 [[ "$(uname -s)" == "Linux" ]] || { echo "ERROR: supervisor installation requires Linux/WSL2" >&2; exit 1; }
 [[ -n "$PYTHON_BIN" ]] || { echo "ERROR: python3 is required" >&2; exit 1; }
-mkdir -p "$SOCKET_DIR"
-chmod 700 "$SOCKET_DIR"
-
 if ! command -v systemctl >/dev/null 2>&1 || [[ ! -d /run/systemd/system ]]; then
   echo "ERROR: systemd is required for the boot-persistent host supervisor." >&2
   echo "On WSL2, enable systemd in /etc/wsl.conf and restart WSL, then rerun this script." >&2
@@ -71,6 +71,8 @@ Restart=on-failure
 RestartSec=2
 NoNewPrivileges=true
 PrivateTmp=true
+RuntimeDirectory=ascento-supervisor
+RuntimeDirectoryMode=0770
 UMask=0007
 
 [Install]

--- a/tests_dashboard/test_install_supervisor.py
+++ b/tests_dashboard/test_install_supervisor.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_supervisor_uses_a_short_systemd_runtime_socket_path():
+    installer = (REPO_ROOT / "scripts" / "install_supervisor.sh").read_text(encoding="utf-8")
+    compose = (REPO_ROOT / "docker" / "compose.yaml").read_text(encoding="utf-8")
+
+    assert 'SOCKET_DIR="/run/ascento-supervisor"' in installer
+    assert "RuntimeDirectory=ascento-supervisor" in installer
+    assert "RuntimeDirectoryMode=0770" in installer
+    assert "/run/ascento-supervisor:/run/ascento-supervisor" in compose
+    assert len("/run/ascento-supervisor/supervisor.sock".encode()) < 108


### PR DESCRIPTION
Summary: move the supervisor socket to systemd's short runtime directory, mount it into the Dashboard container, document the WSL Unix-socket limit, and add a regression guard. Validation: targeted pytest, WSL shell syntax and startup smoke test, Docker Compose config validation, and Ruff.