### PR TITLE
Add adaptive balance and velocity episode horizons

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -45,6 +45,7 @@ class RunCreateRequest(BaseModel):
     purpose: str = ""
     parent_run_id: str | None = None
     parent_checkpoint: str | None = None
+    episode_horizon_s: float | None = Field(default=None)
     training_args: list[str] = Field(default_factory=list)
 
 

--- a/dashboard/frontend/src/RunsPage.jsx
+++ b/dashboard/frontend/src/RunsPage.jsx
@@ -47,6 +47,7 @@ function defaultCreateForm() {
     notes: '',
     parent_run_id: '',
     parent_checkpoint: '',
+    episode_horizon_s: '20',
     training_args: '--env.scene.num-envs\n512\n--agent.max-iterations\n10000',
   }
 }
@@ -132,6 +133,9 @@ function RunsPage() {
         notes: createForm.notes,
         parent_run_id: createForm.parent_run_id || null,
         parent_checkpoint: createForm.parent_checkpoint || null,
+        episode_horizon_s: ['Ascento-Balance-Flat', 'Ascento-Velocity-Flat'].includes(createForm.task)
+          ? Number(createForm.episode_horizon_s)
+          : null,
         training_args: parseArgs(createForm.training_args),
       }
       const created = await fetchJson('/api/runs', {
@@ -330,8 +334,9 @@ function RunsPage() {
               <label>Tags<input value={createForm.tags} onChange={(event) => setCreateForm({ ...createForm, tags: event.target.value })} placeholder="recovery, pr83, baseline" /></label>
               <label>Parent run<select value={createForm.parent_run_id} onChange={(event) => setCreateForm({ ...createForm, parent_run_id: event.target.value })}><option value="">None</option>{runs.map((run) => <option key={run.id} value={run.id}>{run.display_name || run.name}</option>)}</select></label>
               <label>Parent checkpoint<input value={createForm.parent_checkpoint} onChange={(event) => setCreateForm({ ...createForm, parent_checkpoint: event.target.value })} placeholder="model_7500.pt" /></label>
+              {['Ascento-Balance-Flat', 'Ascento-Velocity-Flat'].includes(createForm.task) && <label>Initial episode horizon (seconds)<select value={createForm.episode_horizon_s} onChange={(event) => setCreateForm({ ...createForm, episode_horizon_s: event.target.value })}><option value="20">20 seconds — frequent reset practice</option><option value="60">60 seconds</option><option value="120">120 seconds</option><option value="300">300 seconds — longest horizon</option></select><small>Starts at this horizon, then advances through 20 → 60 → 120 → 300 seconds after three 512-episode windows each reach at least 90% timeout completions. Short early episodes preserve randomized-reset practice.</small></label>}
               <label>Notes<textarea rows="3" value={createForm.notes} onChange={(event) => setCreateForm({ ...createForm, notes: event.target.value })} placeholder="Why this run exists and what should be learned from it." /></label>
-              <label>Training arguments <small>one argument/value per line</small><textarea className="mono" rows="7" value={createForm.training_args} onChange={(event) => setCreateForm({ ...createForm, training_args: event.target.value })} /></label>
+              <label>Advanced training arguments <small>One argument/value per line. Common settings: <code>--env.scene.num-envs</code> controls parallel simulations; <code>--agent.max-iterations</code> controls PPO updates; <code>--agent.seed</code> makes a run repeatable. The episode horizon is set above so it can be recorded and adapted safely.</small><textarea className="mono" rows="7" value={createForm.training_args} onChange={(event) => setCreateForm({ ...createForm, training_args: event.target.value })} /></label>
               <button className="runs-button primary" disabled={busy}>Start training</button>
             </form>
           </section>
@@ -347,7 +352,9 @@ function RunsPage() {
                 <div><span>Iteration</span><strong>{fmtNumber(detail.telemetry?.iteration, 0)}</strong></div>
                 <div><span>Started</span><strong>{fmtDate(detail.run_info?.started_at)}</strong></div>
                 <div><span>Commit</span><strong className="mono">{shortCommit(detail.repository_version?.run_commit)}</strong></div>
+                <div><span>Active horizon</span><strong>{fmtNumber(detail.run_info?.episode_horizon_s ?? detail.run_info?.requested_episode_horizon_s, 0)} s</strong></div>
               </div>
+              {detail.run_info?.command && <details className="runs-command"><summary>Training arguments and launch command</summary><pre>{Array.isArray(detail.run_info.command) ? detail.run_info.command.join('\n') : detail.run_info.command}</pre></details>}
               {active && <button className="runs-button danger full" disabled={busy || detail.state === 'stopping'} onClick={stopRun}>{detail.state === 'stopping' ? 'Stopping…' : 'Graceful stop'}</button>}
               <form className="runs-form edit-form" onSubmit={saveMetadata}>
                 <label>Human name<input value={editForm.display_name} onChange={(event) => setEditForm({ ...editForm, display_name: event.target.value })} /></label>

--- a/dashboard/frontend/src/runs.css
+++ b/dashboard/frontend/src/runs.css
@@ -294,6 +294,27 @@
   display: block;
 }
 
+.runs-command {
+  margin: 0 0 14px;
+  font-size: 12px;
+}
+
+.runs-command summary {
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.runs-command pre {
+  max-height: 220px;
+  overflow: auto;
+  margin: 8px 0 0;
+  padding: 10px;
+  border-radius: 7px;
+  background: rgba(0, 0, 0, 0.2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .runs-summary-grid span {
   font-size: 11px;
   opacity: 0.58;

--- a/dashboard/health.py
+++ b/dashboard/health.py
@@ -549,6 +549,13 @@ def build_run_info(run_dir: Path, root: Path, stage: str) -> dict[str, Any]:
         "seed": seed,
         "command": _first((status, manifest), "command", "command_line"),
         "simulation_timestep": sim_timestep,
+        "episode_horizon_s": _first((status, manifest), "episode_horizon_s"),
+        "requested_episode_horizon_s": _first(
+            (status, manifest), "requested_episode_horizon_s"
+        ),
+        "horizon_stage": _first((status, manifest), "horizon_stage"),
+        "horizon_qualified_windows": _first((status, manifest), "horizon_qualified_windows"),
+        "horizon_timeout_fraction": _first((status, manifest), "horizon_timeout_fraction"),
         "device": device,
         "gpu_world_size": _first((status, manifest, runtime), "gpu_world_size"),
         "checkpoint_path": _first((status, manifest), "checkpoint_path", "model_path")

--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -20,6 +20,10 @@ TRAINING_RUNTIME_RE = re.compile(
     r"Training with:\s*device=([^,\s]+),\s*seed=([^,\s]+),\s*rank=(\d+)"
 )
 GPU_WORLD_RE = re.compile(r"Launching training with\s+(\d+)\s+GPUs?", re.IGNORECASE)
+HORIZON_CURRICULUM_RE = re.compile(
+    r"HORIZON_CURRICULUM\s+horizon_s=(\S+)\s+stage=(\d+)\s+qualified_windows=(\d+)"
+    r"(?:\s+timeout_fraction=(\S+))?"
+)
 
 
 def write_status(path: Path, **values: Any) -> None:
@@ -137,6 +141,13 @@ def _runtime_status_from_line(line: str) -> dict[str, Any]:
     world = GPU_WORLD_RE.search(line)
     if world:
         values["gpu_world_size"] = int(world.group(1))
+    horizon = HORIZON_CURRICULUM_RE.search(line)
+    if horizon:
+        values["episode_horizon_s"] = float(horizon.group(1))
+        values["horizon_stage"] = int(horizon.group(2))
+        values["horizon_qualified_windows"] = int(horizon.group(3))
+        if horizon.group(4) is not None:
+            values["horizon_timeout_fraction"] = float(horizon.group(4))
     return values
 
 
@@ -239,6 +250,7 @@ def main() -> int:
             "--simulation.dt",
         )
     )
+    episode_horizon_s = _number(_training_arg(training_args, "--env.episode-length-s"))
     started = datetime.now(timezone.utc).isoformat()
     git = git_metadata()
     display_name = (args.display_name or run_name).strip()
@@ -271,6 +283,7 @@ def main() -> int:
         seed=seed,
         device=device,
         simulation_timestep=sim_timestep,
+        requested_episode_horizon_s=episode_horizon_s,
         started_at=started,
         command=command,
         command_line=" ".join(command),

--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -178,6 +178,16 @@ class RunService:
         task = str(request.get("task") or "Ascento-Balance-Flat").strip()
         if not task.startswith("Ascento-"):
             raise ValueError("task must be an Ascento task name")
+        episode_horizon_s = request.get("episode_horizon_s")
+        if episode_horizon_s is not None:
+            if task not in {"Ascento-Balance-Flat", "Ascento-Velocity-Flat"}:
+                raise ValueError("episode horizon is currently configurable only for balance and velocity")
+            try:
+                episode_horizon_s = float(episode_horizon_s)
+            except (TypeError, ValueError) as error:
+                raise ValueError("episode_horizon_s must be a number") from error
+            if episode_horizon_s not in {20.0, 60.0, 120.0, 300.0}:
+                raise ValueError("episode_horizon_s must be one of 20, 60, 120, or 300 seconds")
         training_args = request.get("training_args") or []
         if not isinstance(training_args, list) or not all(
             isinstance(value, str) for value in training_args
@@ -220,6 +230,8 @@ class RunService:
             command.extend(["--parent-run-id", str(parent_run_id)])
         if parent_checkpoint:
             command.extend(["--parent-checkpoint", parent_checkpoint])
+        if episode_horizon_s is not None:
+            command.extend(["--env.episode-length-s", str(episode_horizon_s)])
         for tag in _clean_tags(request.get("tags")):
             command.extend(["--tag", tag])
         command.append("--")

--- a/src/ascento_mjlab/horizon_curriculum.py
+++ b/src/ascento_mjlab/horizon_curriculum.py
@@ -1,0 +1,95 @@
+"""Adaptive episode-horizon curriculum for long-horizon locomotion tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
+
+
+HORIZON_SCHEDULE_S = (20.0, 60.0, 120.0, 300.0)
+"""Successive episode horizons used by balance and velocity training."""
+
+
+class HorizonCurriculumRunner(MjlabOnPolicyRunner):
+    """Promote a run after sustained timeout-based episode success.
+
+    Each completion window contains a fixed number of finished vector slots.
+    The horizon advances only after three consecutive windows have at least 90%
+    timeouts, keeping frequent randomized resets while the policy is unstable.
+    """
+
+    env: RslRlVecEnvWrapper
+    completion_window_episodes = 512
+    required_success_windows = 3
+    timeout_success_threshold = 0.90
+
+    def __init__(
+        self,
+        env: RslRlVecEnvWrapper,
+        train_cfg: dict[str, Any],
+        log_dir: str | None = None,
+        device: str = "cpu",
+    ) -> None:
+        super().__init__(env, train_cfg, log_dir, device)
+        self._completed_in_window = 0
+        self._timeouts_in_window = 0
+        self._successful_windows = 0
+        self._schedule_index = self._schedule_index_for(env.unwrapped.max_episode_length_s)
+        self._base_step: Callable[[torch.Tensor], tuple[Any, torch.Tensor, torch.Tensor, dict]] = env.step
+        env.step = self._step  # type: ignore[method-assign]
+        self._emit_status(timeout_fraction=None)
+
+    @staticmethod
+    def _schedule_index_for(horizon_s: float) -> int:
+        """Start at the first configured horizon not below the requested value."""
+        for index, candidate in enumerate(HORIZON_SCHEDULE_S):
+            if horizon_s <= candidate:
+                return index
+        return len(HORIZON_SCHEDULE_S) - 1
+
+    def _step(self, actions: torch.Tensor) -> tuple[Any, torch.Tensor, torch.Tensor, dict]:
+        observations, rewards, dones, extras = self._base_step(actions)
+        timeouts = self.env.unwrapped.reset_time_outs
+        completed = int(dones.sum().item())
+        if completed:
+            self._completed_in_window += completed
+            self._timeouts_in_window += int((timeouts & dones.bool()).sum().item())
+            if self._completed_in_window >= self.completion_window_episodes:
+                self._evaluate_completion_window()
+        return observations, rewards, dones, extras
+
+    def _evaluate_completion_window(self) -> None:
+        timeout_fraction = self._timeouts_in_window / self._completed_in_window
+        if timeout_fraction >= self.timeout_success_threshold:
+            self._successful_windows += 1
+        else:
+            self._successful_windows = 0
+
+        if (
+            self._successful_windows >= self.required_success_windows
+            and self._schedule_index < len(HORIZON_SCHEDULE_S) - 1
+        ):
+            self._schedule_index += 1
+            self.env.unwrapped.cfg.episode_length_s = HORIZON_SCHEDULE_S[self._schedule_index]
+            # RSL-RL consults this wrapper field for initial random episode
+            # lengths; the environment itself derives timeout length dynamically
+            # from cfg.episode_length_s on every step.
+            self.env.max_episode_length = self.env.unwrapped.max_episode_length
+            self._successful_windows = 0
+
+        self._emit_status(timeout_fraction=timeout_fraction)
+        self._completed_in_window = 0
+        self._timeouts_in_window = 0
+
+    def _emit_status(self, *, timeout_fraction: float | None) -> None:
+        parts = [
+            f"horizon_s={self.env.unwrapped.max_episode_length_s:.1f}",
+            f"stage={self._schedule_index + 1}",
+            f"qualified_windows={self._successful_windows}",
+        ]
+        if timeout_fraction is not None:
+            parts.append(f"timeout_fraction={timeout_fraction:.4f}")
+        print("HORIZON_CURRICULUM " + " ".join(parts), flush=True)

--- a/src/ascento_mjlab/horizon_curriculum.py
+++ b/src/ascento_mjlab/horizon_curriculum.py
@@ -8,7 +8,6 @@ from typing import Any
 import torch
 from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
 
-
 HORIZON_SCHEDULE_S = (20.0, 60.0, 120.0, 300.0)
 """Successive episode horizons used by balance and velocity training."""
 

--- a/src/ascento_mjlab/tasks/__init__.py
+++ b/src/ascento_mjlab/tasks/__init__.py
@@ -3,6 +3,8 @@
 # Import configuration modules before touching mjlab's registry. mjlab
 # discovers task entry points while its own task package is being imported;
 # keeping registry access lazy makes both import directions safe.
+from ascento_mjlab.horizon_curriculum import HorizonCurriculumRunner
+
 from .balance.env_cfg import ascento_balance_env_cfg
 from .balance.rl_cfg import AscentoBalanceRlCfg
 from .jump.env_cfg import ascento_jump_env_cfg
@@ -22,12 +24,14 @@ def _register_tasks() -> None:
         env_cfg=ascento_balance_env_cfg(),
         play_env_cfg=ascento_balance_env_cfg(play=True),
         rl_cfg=AscentoBalanceRlCfg,
+        runner_cls=HorizonCurriculumRunner,
     )
     register_mjlab_task(
         task_id="Ascento-Velocity-Flat",
         env_cfg=ascento_velocity_env_cfg(),
         play_env_cfg=ascento_velocity_env_cfg(play=True),
         rl_cfg=AscentoVelocityRlCfg,
+        runner_cls=HorizonCurriculumRunner,
     )
     register_mjlab_task(
         task_id="Ascento-Recovery-Flat",

--- a/tests_dashboard/test_config_launch.py
+++ b/tests_dashboard/test_config_launch.py
@@ -37,6 +37,14 @@ def test_launcher_extracts_runtime_device_seed_and_world_size():
     assert _runtime_status_from_line("[INFO] Launching training with 2 GPUs") == {
         "gpu_world_size": 2
     }
+    assert _runtime_status_from_line(
+        "HORIZON_CURRICULUM horizon_s=60.0 stage=2 qualified_windows=0 timeout_fraction=0.9219"
+    ) == {
+        "episode_horizon_s": 60.0,
+        "horizon_stage": 2,
+        "horizon_qualified_windows": 0,
+        "horizon_timeout_fraction": 0.9219,
+    }
 
 
 def test_launcher_uses_injected_repository_version_without_git(monkeypatch):

--- a/tests_dashboard/test_run_service.py
+++ b/tests_dashboard/test_run_service.py
@@ -126,6 +126,7 @@ def test_create_starts_detached_launcher_with_metadata_arguments(monkeypatch, tm
         {
             "display_name": "Velocity validation",
             "task": "Ascento-Velocity-Flat",
+            "episode_horizon_s": 60,
             "purpose": "validation",
             "tags": ["velocity", "gate"],
             "notes": "Verify the current gate.",
@@ -140,7 +141,22 @@ def test_create_starts_detached_launcher_with_metadata_arguments(monkeypatch, tm
     assert "--display-name" in command
     assert "Velocity validation" in command
     assert command[-2:] == ["--agent.max-iterations", "5000"]
+    assert "--env.episode-length-s" in command
+    assert command[command.index("--env.episode-length-s") + 1] == "60.0"
     assert captured["kwargs"]["start_new_session"] is True
+
+
+def test_create_rejects_horizon_for_non_progressive_tasks(tmp_path):
+    service = RunService(tmp_path)
+
+    with pytest.raises(ValueError, match="only for balance and velocity"):
+        service.create(
+            {
+                "display_name": "Jump validation",
+                "task": "Ascento-Jump-Flat",
+                "episode_horizon_s": 60,
+            }
+        )
 
 
 def test_stop_marks_stopping_before_signalling(monkeypatch, tmp_path):

--- a/tests_mjlab/test_horizon_curriculum.py
+++ b/tests_mjlab/test_horizon_curriculum.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from ascento_mjlab.horizon_curriculum import HORIZON_SCHEDULE_S, HorizonCurriculumRunner
+
+
+def _runner(horizon_s=20.0):
+    runner = object.__new__(HorizonCurriculumRunner)
+    runner.env = SimpleNamespace(
+        unwrapped=SimpleNamespace(
+            cfg=SimpleNamespace(episode_length_s=horizon_s),
+            max_episode_length_s=horizon_s,
+            max_episode_length=int(horizon_s * 100),
+        ),
+        max_episode_length=int(horizon_s * 100),
+    )
+    runner._completed_in_window = 0
+    runner._timeouts_in_window = 0
+    runner._successful_windows = 0
+    runner._schedule_index = runner._schedule_index_for(horizon_s)
+    return runner
+
+
+def test_horizon_schedule_starts_at_the_requested_stage():
+    assert HorizonCurriculumRunner._schedule_index_for(20.0) == 0
+    assert HorizonCurriculumRunner._schedule_index_for(60.0) == 1
+    assert HorizonCurriculumRunner._schedule_index_for(300.0) == 3
+
+
+def test_horizon_requires_three_qualified_completion_windows(monkeypatch):
+    runner = _runner()
+    monkeypatch.setattr(runner, "_emit_status", lambda **_: None)
+    for _ in range(2):
+        runner._completed_in_window = 512
+        runner._timeouts_in_window = 461
+        runner._evaluate_completion_window()
+        assert runner.env.unwrapped.cfg.episode_length_s == 20.0
+
+    runner._completed_in_window = 512
+    runner._timeouts_in_window = 461
+    runner._evaluate_completion_window()
+
+    assert runner.env.unwrapped.cfg.episode_length_s == 60.0
+
+
+def test_horizon_resets_the_streak_after_a_failing_window(monkeypatch):
+    runner = _runner()
+    monkeypatch.setattr(runner, "_emit_status", lambda **_: None)
+    runner._completed_in_window = 512
+    runner._timeouts_in_window = 512
+    runner._evaluate_completion_window()
+    runner._completed_in_window = 512
+    runner._timeouts_in_window = 450
+    runner._evaluate_completion_window()
+
+    assert runner._successful_windows == 0
+    assert runner.env.unwrapped.cfg.episode_length_s == HORIZON_SCHEDULE_S[0]


### PR DESCRIPTION
Adds an adaptive episode-horizon curriculum for balance and velocity training.

- Starts at a selected stage: 20, 60, 120, or 300 seconds.
- Promotes 20 → 60 → 120 → 300 only after three consecutive completion windows of 512 ended episodes each have at least 90% timeouts.
- Uses timeouts rather than reward as the promotion signal, preserving frequent randomized resets while the policy still falls or exceeds velocity limits.
- Adds a dashboard selector that writes `--env.episode-length-s`, explains common advanced arguments, and displays the exact launch command plus active horizon.
- Adds unit coverage for stage promotion, failed-window reset, launch validation, and runtime-status parsing.

Recovery and jump horizons are unchanged.