### PR TITLE
Fix dashboard run creation race

### DIFF
--- a/dashboard/launch.py
+++ b/dashboard/launch.py
@@ -188,6 +188,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--run-id", help="stable dashboard run id; generated automatically when omitted"
     )
+    parser.add_argument(
+        "--preinitialized",
+        action="store_true",
+        help="reuse the empty run directory initialized synchronously by the dashboard API",
+    )
     parser.add_argument("--display-name", help="human-readable run name shown by the dashboard")
     parser.add_argument("--notes", default="", help="human notes stored with the run")
     parser.add_argument("--tag", action="append", default=[], help="repeatable run tag")
@@ -214,7 +219,11 @@ def main() -> int:
     run_dir = (args.artifact_root.expanduser().resolve() / run_name).resolve()
 
     try:
-        if run_dir.exists() and any(run_dir.iterdir()):
+        expected_files = {"run_metadata.json", "run_status.json"}
+        existing_files = {path.name for path in run_dir.iterdir()} if run_dir.exists() else set()
+        if args.preinitialized and existing_files != expected_files:
+            parser.error(f"preinitialized run directory is incomplete: {run_dir}")
+        if not args.preinitialized and existing_files:
             parser.error(f"run directory already exists and is not empty: {run_dir}")
         run_dir.mkdir(parents=True, exist_ok=True)
     except OSError as error:

--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -204,6 +204,43 @@ class RunService:
         stable_run_id = uuid4().hex[:12]
         stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         directory_name = f"{stamp}_{_slug(display_name)}_{stable_run_id[:8]}"
+        run_dir = self.artifact_root / directory_name
+        started_at = _now()
+        try:
+            # Make the returned run ID immediately readable. Previously the
+            # detached launcher created these files asynchronously, so the UI
+            # could request its detail endpoint before the directory existed.
+            run_dir.mkdir()
+            _write_json(
+                run_dir / RUN_METADATA,
+                {
+                    "schema_version": 1,
+                    "run_id": stable_run_id,
+                    "display_name": display_name,
+                    "notes": str(request.get("notes") or "").strip(),
+                    "tags": _clean_tags(request.get("tags")),
+                    "purpose": str(request.get("purpose") or "").strip(),
+                    "parent_run_id": str(parent_run_id) if parent_run_id else None,
+                    "parent_checkpoint": str(request.get("parent_checkpoint") or "").strip(),
+                    "created_at": started_at,
+                    "updated_at": started_at,
+                },
+            )
+            _write_json(
+                run_dir / "run_status.json",
+                {
+                    "schema_version": 4,
+                    "state": "starting",
+                    "run_id": stable_run_id,
+                    "task": task,
+                    "stage": task.removeprefix("Ascento-").removesuffix("-Flat").lower(),
+                    "display_name": display_name,
+                    "started_at": started_at,
+                },
+            )
+        except OSError as error:
+            raise OSError(f"cannot initialize run directory {run_dir}: {error}") from error
+
         command = [
             sys.executable,
             "-m",
@@ -218,6 +255,7 @@ class RunService:
             stable_run_id,
             "--display-name",
             display_name,
+            "--preinitialized",
         ]
         notes = str(request.get("notes") or "").strip()
         purpose = str(request.get("purpose") or "").strip()
@@ -237,15 +275,30 @@ class RunService:
         command.append("--")
         command.extend(training_args)
 
-        process = subprocess.Popen(
-            command,
-            cwd=REPO_ROOT,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            close_fds=True,
-        )
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except OSError as error:
+            status = _load_json(run_dir / "run_status.json")
+            status.update(
+                {
+                    "state": "failed",
+                    "finished_at": _now(),
+                    "error": f"dashboard launcher could not start: {error}",
+                }
+            )
+            _write_json(run_dir / "run_status.json", status)
+            raise
+        status = _load_json(run_dir / "run_status.json")
+        status["launcher_pid"] = process.pid
+        _write_json(run_dir / "run_status.json", status)
         return {
             "id": stable_run_id,
             "name": directory_name,

--- a/tests_dashboard/test_run_api.py
+++ b/tests_dashboard/test_run_api.py
@@ -1,4 +1,6 @@
 import importlib
+import subprocess
+from types import SimpleNamespace
 
 
 def _load_app(monkeypatch, artifact_root):
@@ -47,3 +49,29 @@ def test_create_request_preserves_lineage_and_training_args(monkeypatch, tmp_pat
     assert captured["parent_run_id"] == "parent123"
     assert captured["parent_checkpoint"] == "model_7500.pt"
     assert captured["training_args"][-1] == "12000"
+
+
+def test_created_run_is_immediately_discoverable(monkeypatch, tmp_path):
+    """The create response must not point at a run the detail route cannot read."""
+    module = _load_app(monkeypatch, tmp_path)
+
+    class FakeProcess:
+        pid = 4321
+
+    monkeypatch.setattr(
+        "dashboard.run_service.subprocess",
+        SimpleNamespace(Popen=lambda *args, **kwargs: FakeProcess(), DEVNULL=subprocess.DEVNULL),
+    )
+    created = module.create_run(
+        module.RunCreateRequest(
+            display_name="adaptive-balance-horizons",
+            task="Ascento-Balance-Flat",
+            episode_horizon_s=20,
+        )
+    )
+
+    detail = module.run_status(created["id"])
+
+    assert detail["id"] == created["id"]
+    assert detail["state"] == "starting"
+    assert detail["status"]["launcher_pid"] == 4321

--- a/tests_dashboard/test_run_service.py
+++ b/tests_dashboard/test_run_service.py
@@ -143,7 +143,15 @@ def test_create_starts_detached_launcher_with_metadata_arguments(monkeypatch, tm
     assert command[-2:] == ["--agent.max-iterations", "5000"]
     assert "--env.episode-length-s" in command
     assert command[command.index("--env.episode-length-s") + 1] == "60.0"
+    assert "--preinitialized" in command
     assert captured["kwargs"]["start_new_session"] is True
+
+    run = service.resolve(created["id"])
+    status = json.loads((run.path / "run_status.json").read_text(encoding="utf-8"))
+    metadata = json.loads((run.path / "run_metadata.json").read_text(encoding="utf-8"))
+    assert status["state"] == "starting"
+    assert status["launcher_pid"] == 4321
+    assert metadata["run_id"] == created["id"]
 
 
 def test_create_rejects_horizon_for_non_progressive_tasks(tmp_path):


### PR DESCRIPTION
Fixes #100.

Fixes the dashboard race where `POST /api/runs` returned a new ID before the detached launcher had created its artifacts, causing an immediate `GET /api/runs/<id>` to return 404.

The API now persists the initial directory, metadata, and starting status before it launches the background process. The integration regression test creates a run via the API and verifies that its detail endpoint immediately resolves it as active.