### PR TITLE
Fix dashboard training launch with episode horizons

### DIFF
--- a/dashboard/run_service.py
+++ b/dashboard/run_service.py
@@ -268,11 +268,16 @@ class RunService:
             command.extend(["--parent-run-id", str(parent_run_id)])
         if parent_checkpoint:
             command.extend(["--parent-checkpoint", parent_checkpoint])
-        if episode_horizon_s is not None:
-            command.extend(["--env.episode-length-s", str(episode_horizon_s)])
         for tag in _clean_tags(request.get("tags")):
             command.extend(["--tag", tag])
+        # Everything following this separator belongs to mjlab's trainer.  In
+        # particular, ``--env.episode-length-s`` is not an option understood
+        # by this launcher.  Keeping it before the separator made argparse
+        # terminate the detached launcher before it could write its status or
+        # training log, leaving dashboard-created runs stuck at "starting".
         command.append("--")
+        if episode_horizon_s is not None:
+            command.extend(["--env.episode-length-s", str(episode_horizon_s)])
         command.extend(training_args)
 
         try:

--- a/tests_dashboard/test_config_launch.py
+++ b/tests_dashboard/test_config_launch.py
@@ -28,6 +28,31 @@ def test_launcher_argument_metadata_parser_supports_both_cli_forms():
     assert _training_arg(args, "--env.sim.mujoco.timestep") == "0.002"
 
 
+def test_launcher_accepts_dashboard_horizon_after_training_separator():
+    args = build_parser().parse_args(
+        [
+            "--artifact-root",
+            "/tmp/runs",
+            "--name",
+            "dashboard-run",
+            "--preinitialized",
+            "--",
+            "--env.episode-length-s",
+            "20.0",
+            "--env.scene.num-envs",
+            "512",
+        ]
+    )
+
+    assert args.training_args == [
+        "--",
+        "--env.episode-length-s",
+        "20.0",
+        "--env.scene.num-envs",
+        "512",
+    ]
+
+
 def test_launcher_extracts_runtime_device_seed_and_world_size():
     assert _runtime_status_from_line("[INFO] Training with: device=cuda:0, seed=42, rank=0") == {
         "device": "cuda:0",

--- a/tests_dashboard/test_run_service.py
+++ b/tests_dashboard/test_run_service.py
@@ -141,7 +141,8 @@ def test_create_starts_detached_launcher_with_metadata_arguments(monkeypatch, tm
     assert "--display-name" in command
     assert "Velocity validation" in command
     assert command[-2:] == ["--agent.max-iterations", "5000"]
-    assert "--env.episode-length-s" in command
+    separator = command.index("--")
+    assert command.index("--env.episode-length-s") > separator
     assert command[command.index("--env.episode-length-s") + 1] == "60.0"
     assert "--preinitialized" in command
     assert captured["kwargs"]["start_new_session"] is True


### PR DESCRIPTION
## Summary
- send the dashboard-selected episode horizon after the launcher-to-trainer argument separator
- prevent argparse from rejecting the default dashboard launch request before status/log initialization
- cover the dashboard default horizon command path with regression tests

## Verification
- ..............                                                           [100%]
14 passed in 0.39s
- All checks passed!