### PR TITLE
Speed up dashboard refreshes

### DIFF
--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -9,7 +9,11 @@ import {
   YAxis,
 } from 'recharts'
 
-const POLL_MS = 5000
+const POLL_MS = 15000
+const TELEMETRY_LIMIT = 750
+const LOG_TAIL_LIMIT = 400
+const LOG_DISPLAY_LIMIT = 600
+const LOG_FLUSH_MS = 500
 const CANONICAL_CHARTS = [
   { key: 'reward', label: 'Reward trend' },
   { key: 'episode_length', label: 'Episode length trend' },
@@ -125,6 +129,11 @@ function App() {
   const [autoScroll, setAutoScroll] = useState(true)
   const [copyState, setCopyState] = useState('')
   const terminalRef = useRef(null)
+  const healthRefreshInFlight = useRef(false)
+  const runsRefreshInFlight = useRef(false)
+  const selectedRefreshInFlight = useRef(false)
+  const pendingLogLines = useRef([])
+  const logFlushTimer = useRef(null)
 
   async function fetchJson(url, options) {
     const response = await fetch(url, options)
@@ -136,15 +145,21 @@ function App() {
   }
 
   async function refreshHealth() {
+    if (healthRefreshInFlight.current) return
+    healthRefreshInFlight.current = true
     try {
       const data = await fetchJson('/api/health')
       setHealth(data)
     } catch (error) {
       setHealth({ ok: false, problems: [error.message] })
+    } finally {
+      healthRefreshInFlight.current = false
     }
   }
 
   async function refreshRuns() {
+    if (runsRefreshInFlight.current) return
+    runsRefreshInFlight.current = true
     try {
       const data = await fetchJson('/api/runs')
       const nextRuns = data.runs || []
@@ -156,6 +171,8 @@ function App() {
       setApiError('')
     } catch (error) {
       setApiError(error.message)
+    } finally {
+      runsRefreshInFlight.current = false
     }
   }
 
@@ -165,16 +182,20 @@ function App() {
       setTelemetry([])
       return
     }
+    if (selectedRefreshInFlight.current) return
+    selectedRefreshInFlight.current = true
     try {
       const [run, points] = await Promise.all([
         fetchJson(`/api/runs/${id}`),
-        fetchJson(`/api/runs/${id}/telemetry?limit=3000`),
+        fetchJson(`/api/runs/${id}/telemetry?limit=${TELEMETRY_LIMIT}`),
       ])
       setDetail(run)
       setTelemetry(points.records || [])
       setApiError('')
     } catch (error) {
       setApiError(error.message)
+    } finally {
+      selectedRefreshInFlight.current = false
     }
   }
 
@@ -203,15 +224,24 @@ function App() {
     if (!selectedId) return undefined
     let cancelled = false
     setLogs([])
-    fetchJson(`/api/runs/${selectedId}/logs?tail=800`)
-      .then((data) => !cancelled && setLogs(data.lines || []))
+    pendingLogLines.current = []
+    fetchJson(`/api/runs/${selectedId}/logs?tail=${LOG_TAIL_LIMIT}`)
+      .then((data) => !cancelled && setLogs((data.lines || []).slice(-LOG_DISPLAY_LIMIT)))
       .catch(() => {})
     const source = new EventSource(`/api/runs/${selectedId}/logs/stream`)
+    const flushLogLines = () => {
+      logFlushTimer.current = null
+      const lines = pendingLogLines.current.splice(0)
+      if (lines.length) setLogs((current) => [...current, ...lines].slice(-LOG_DISPLAY_LIMIT))
+    }
     source.onmessage = (event) => {
       try {
         const value = JSON.parse(event.data)
         if (typeof value.line === 'string') {
-          setLogs((current) => [...current, value.line].slice(-1500))
+          pendingLogLines.current.push(value.line)
+          if (logFlushTimer.current === null) {
+            logFlushTimer.current = setTimeout(flushLogLines, LOG_FLUSH_MS)
+          }
         }
       } catch (_) {
         // Ignore malformed log events; the stream will continue.
@@ -220,6 +250,9 @@ function App() {
     return () => {
       cancelled = true
       source.close()
+      pendingLogLines.current = []
+      if (logFlushTimer.current !== null) clearTimeout(logFlushTimer.current)
+      logFlushTimer.current = null
     }
   }, [selectedId])
 

--- a/dashboard/frontend/src/RunsPage.jsx
+++ b/dashboard/frontend/src/RunsPage.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-const POLL_MS = 5000
+const POLL_MS = 15000
 const TASKS = [
   'Ascento-Balance-Flat',
   'Ascento-Velocity-Flat',
@@ -69,8 +69,13 @@ function RunsPage() {
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
   const [busy, setBusy] = useState(false)
+  const runsRefreshInFlight = useRef(false)
+  const detailRefreshInFlight = useRef(false)
+  const editFormRunId = useRef('')
 
   async function refreshRuns() {
+    if (runsRefreshInFlight.current) return
+    runsRefreshInFlight.current = true
     try {
       const data = await fetchJson('/api/runs')
       const next = data.runs || []
@@ -79,28 +84,38 @@ function RunsPage() {
       setError('')
     } catch (caught) {
       setError(caught.message)
+    } finally {
+      runsRefreshInFlight.current = false
     }
   }
 
   async function refreshDetail(id) {
     if (!id) {
       setDetail(null)
+      editFormRunId.current = ''
       return
     }
+    if (detailRefreshInFlight.current) return
+    detailRefreshInFlight.current = true
     try {
       const value = await fetchJson(`/api/runs/${id}`)
       setDetail(value)
-      setEditForm({
-        display_name: value.display_name || value.name || '',
-        purpose: value.metadata?.purpose || '',
-        tags: (value.tags || []).join(', '),
-        notes: value.notes || '',
-        parent_run_id: value.lineage?.parent_run_id || '',
-        parent_checkpoint: value.lineage?.parent_checkpoint || '',
-      })
+      if (editFormRunId.current !== id) {
+        editFormRunId.current = id
+        setEditForm({
+          display_name: value.display_name || value.name || '',
+          purpose: value.metadata?.purpose || '',
+          tags: (value.tags || []).join(', '),
+          notes: value.notes || '',
+          parent_run_id: value.lineage?.parent_run_id || '',
+          parent_checkpoint: value.lineage?.parent_checkpoint || '',
+        })
+      }
       setError('')
     } catch (caught) {
       setError(caught.message)
+    } finally {
+      detailRefreshInFlight.current = false
     }
   }
 

--- a/dashboard/health.py
+++ b/dashboard/health.py
@@ -296,7 +296,9 @@ def _has_training_signal(path: Path) -> bool:
         return True
     if (path / "params" / "agent.yaml").is_file():
         return True
-    if any(path.glob("events.out.tfevents.*")) or any(path.glob("model_*.pt")):
+    if next(path.glob("events.out.tfevents.*"), None) is not None:
+        return True
+    if next(path.glob("model_*.pt"), None) is not None:
         return True
     return False
 
@@ -304,12 +306,13 @@ def _has_training_signal(path: Path) -> bool:
 def discover_dashboard_runs(root: Path) -> list[monitor.RunRef]:
     refs = monitor.discover_runs(root)
     paths = {ref.path.resolve() for ref in refs}
+    signals = {path: _has_training_signal(path) for path in paths}
     filtered: list[monitor.RunRef] = []
     for ref in refs:
         path = ref.path.resolve()
-        launcher_only = (path / "run_status.json").is_file() and not _has_training_signal(path)
+        launcher_only = (path / "run_status.json").is_file() and not signals[path]
         has_nested_signal = any(
-            other != path and _inside(other, path) and _has_training_signal(other)
+            other != path and _inside(other, path) and signals[other]
             for other in paths
         )
         if launcher_only and has_nested_signal:
@@ -601,11 +604,21 @@ def summarize_dashboard_run(
     *,
     stale_after_seconds: float = 90.0,
     detailed: bool = False,
+    include_telemetry: bool = True,
+    include_errors: bool = True,
+    include_artifacts: bool = True,
     now: float | None = None,
 ) -> dict[str, Any]:
     now = time.time() if now is None else now
-    base = monitor.summarize_run(run_dir, root, now=now)
-    records = load_dashboard_records(run_dir, limit=500 if detailed else 1)
+    base = monitor.summarize_run(
+        run_dir,
+        root,
+        now=now,
+        include_telemetry=include_telemetry,
+        include_errors=include_errors,
+        include_artifacts=include_artifacts,
+    )
+    records = load_dashboard_records(run_dir, limit=500 if detailed else 1) if include_telemetry else []
     latest = records[-1] if records else None
     status_file = run_status_path(run_dir, root)
     status = _json(status_file) or base.get("status") or {}
@@ -650,6 +663,13 @@ def list_dashboard_summaries(
     root: Path, *, stale_after_seconds: float = 90.0
 ) -> list[dict[str, Any]]:
     return [
-        summarize_dashboard_run(ref.path, root, stale_after_seconds=stale_after_seconds)
+        summarize_dashboard_run(
+            ref.path,
+            root,
+            stale_after_seconds=stale_after_seconds,
+            include_telemetry=False,
+            include_errors=False,
+            include_artifacts=False,
+        )
         for ref in discover_dashboard_runs(root)
     ]

--- a/dashboard/monitor.py
+++ b/dashboard/monitor.py
@@ -15,6 +15,19 @@ ERROR_PATTERN = re.compile(
     r"(traceback|\berror\b|exception|floatingpointerror|non-finite|cuda.*fail|out of memory|oom)",
     re.IGNORECASE,
 )
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+LOG_ITERATION_RE = re.compile(r"Learning iteration\s+(\d+)/(\d+)")
+LOG_METRIC_PATTERNS = {
+    "Total steps": "total_environment_steps",
+    "Steps per second": "Perf/total_fps",
+    "Mean value loss": "Loss/value",
+    "Mean surrogate loss": "Loss/surrogate",
+    "Mean entropy loss": "Loss/entropy",
+    "Mean kl loss": "Loss/kl",
+    "Mean clip_fraction loss": "Loss/clip_fraction",
+    "Mean reward": "Train/mean_reward",
+    "Mean episode length": "Train/mean_episode_length",
+}
 RUN_MARKERS = (
     "telemetry.jsonl",
     "training.log",
@@ -26,6 +39,9 @@ _TENSORBOARD_RECORD_CACHE: dict[
     Path, tuple[tuple[tuple[str, int, int], ...], int | None, list[dict[str, Any]]]
 ] = {}
 _TENSORBOARD_LOCK = threading.Lock()
+_DISCOVERY_CACHE: dict[Path, tuple[float, list["RunRef"]]] = {}
+_DISCOVERY_LOCK = threading.Lock()
+_DISCOVERY_CACHE_TTL_S = 2.0
 
 
 @dataclass(frozen=True)
@@ -159,8 +175,11 @@ def load_tensorboard_records(run_dir: Path, limit: int | None = 2000) -> list[di
 
 
 def load_training_records(run_dir: Path, limit: int | None = 2000) -> list[dict[str, Any]]:
-    """Read legacy JSON telemetry or native RSL-RL TensorBoard telemetry."""
+    """Read JSON telemetry, lightweight console telemetry, or TensorBoard data."""
     records = load_jsonl(run_dir / "telemetry.jsonl", limit=limit)
+    if records:
+        return records
+    records = load_log_records(run_dir, limit=limit)
     return records if records else load_tensorboard_records(run_dir, limit=limit)
 
 
@@ -178,13 +197,66 @@ def training_log_path(run_dir: Path, root: Path | None = None) -> Path:
 
 
 def tail_lines(path: Path, count: int = 400) -> list[str]:
+    """Read only the requested tail instead of loading an entire training log."""
     if count <= 0 or not path.is_file():
         return []
     try:
-        with path.open("r", encoding="utf-8", errors="replace") as handle:
-            return handle.readlines()[-count:]
+        with path.open("rb") as handle:
+            handle.seek(0, 2)
+            position = handle.tell()
+            chunks: list[bytes] = []
+            newline_count = 0
+            while position > 0 and newline_count <= count:
+                start = max(0, position - 64 * 1024)
+                handle.seek(start)
+                chunk = handle.read(position - start)
+                chunks.append(chunk)
+                newline_count += chunk.count(b"\n")
+                position = start
     except OSError:
         return []
+    return b"".join(reversed(chunks)).decode("utf-8", errors="replace").splitlines(keepends=True)[-count:]
+
+
+def load_log_records(run_dir: Path, limit: int | None = 2000) -> list[dict[str, Any]]:
+    """Extract recent trainer metrics from the bounded console tail.
+
+    RSL-RL writes every training statistic to stdout. Parsing that small tail
+    keeps the dashboard responsive while a TensorBoard file grows to hundreds of
+    megabytes on a mounted workspace. TensorBoard remains the fallback for runs
+    without the standard trainer output.
+    """
+    log_path = training_log_path(run_dir)
+    lines = tail_lines(log_path, 8000)
+    if not lines:
+        return []
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for raw_line in lines:
+        line = ANSI_ESCAPE_RE.sub("", raw_line).strip()
+        iteration = LOG_ITERATION_RE.search(line)
+        if iteration:
+            if current is not None:
+                records.append(current)
+            current = {
+                "completed_steps": int(iteration.group(1)),
+                "total_steps": int(iteration.group(2)),
+                "metrics": {},
+            }
+            continue
+        if current is None or ":" not in line:
+            continue
+        label, raw_value = (part.strip() for part in line.split(":", 1))
+        metric = LOG_METRIC_PATTERNS.get(label)
+        if metric is None:
+            continue
+        try:
+            current["metrics"][metric] = float(raw_value)
+        except ValueError:
+            continue
+    if current is not None:
+        records.append(current)
+    return records[-limit:] if limit is not None else records
 
 
 def error_excerpt(path: Path, max_lines: int = 80) -> list[str]:
@@ -203,22 +275,30 @@ def discover_runs(root: Path) -> list[RunRef]:
     root = root.expanduser().resolve()
     if not root.exists():
         return []
-    candidates: set[Path] = set()
-    if any((root / marker).exists() for marker in RUN_MARKERS):
-        candidates.add(root)
-    for marker in RUN_MARKERS:
-        for path in root.rglob(marker):
-            candidates.add(path.parent.resolve())
-    for pattern in ("events.out.tfevents.*", "model_*.pt"):
-        for path in root.rglob(pattern):
-            candidates.add(path.parent.resolve())
-    refs = []
-    for path in candidates:
-        if not _inside(path, root):
-            continue
-        relative = "." if path == root else path.relative_to(root).as_posix()
-        refs.append(RunRef(sha1(relative.encode("utf-8")).hexdigest()[:12], path, relative))
-    return sorted(refs, key=lambda ref: run_modified_time(ref.path), reverse=True)
+    now = time.monotonic()
+    with _DISCOVERY_LOCK:
+        cached = _DISCOVERY_CACHE.get(root)
+        if cached and now - cached[0] < _DISCOVERY_CACHE_TTL_S:
+            return list(cached[1])
+
+        candidates: set[Path] = set()
+        if any((root / marker).exists() for marker in RUN_MARKERS):
+            candidates.add(root)
+        for marker in RUN_MARKERS:
+            for path in root.rglob(marker):
+                candidates.add(path.parent.resolve())
+        for pattern in ("events.out.tfevents.*", "model_*.pt"):
+            for path in root.rglob(pattern):
+                candidates.add(path.parent.resolve())
+        refs = []
+        for path in candidates:
+            if not _inside(path, root):
+                continue
+            relative = "." if path == root else path.relative_to(root).as_posix()
+            refs.append(RunRef(sha1(relative.encode("utf-8")).hexdigest()[:12], path, relative))
+        result = sorted(refs, key=lambda ref: run_modified_time(ref.path), reverse=True)
+        _DISCOVERY_CACHE[root] = (time.monotonic(), result)
+        return list(result)
 
 
 def resolve_run(root: Path, run_id: str) -> RunRef:
@@ -229,6 +309,7 @@ def resolve_run(root: Path, run_id: str) -> RunRef:
 
 
 def run_modified_time(run_dir: Path) -> float:
+    """Use direct run markers; enumerating every checkpoint stalls mounted drives."""
     mtimes = []
     for marker in RUN_MARKERS:
         path = run_dir / marker
@@ -236,13 +317,17 @@ def run_modified_time(run_dir: Path) -> float:
             mtimes.append(path.stat().st_mtime)
         except OSError:
             pass
-    for pattern in ("events.out.tfevents.*", "model_*.pt"):
-        for path in run_dir.glob(pattern):
-            try:
-                mtimes.append(path.stat().st_mtime)
-            except OSError:
-                pass
-    return max(mtimes, default=run_dir.stat().st_mtime if run_dir.exists() else 0.0)
+    for path in run_dir.glob("events.out.tfevents.*"):
+        try:
+            mtimes.append(path.stat().st_mtime)
+        except OSError:
+            pass
+    if mtimes:
+        return max(mtimes)
+    try:
+        return run_dir.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def _stage_name(
@@ -297,14 +382,22 @@ def latest_render(run_dir: Path) -> dict[str, Any] | None:
     return {"filename": path.name, "relative_path": path.relative_to(run_dir).as_posix()}
 
 
-def summarize_run(run_dir: Path, root: Path, now: float | None = None) -> dict[str, Any]:
+def summarize_run(
+    run_dir: Path,
+    root: Path,
+    now: float | None = None,
+    *,
+    include_telemetry: bool = True,
+    include_errors: bool = True,
+    include_artifacts: bool = True,
+) -> dict[str, Any]:
     now = time.time() if now is None else now
-    telemetry_records = load_training_records(run_dir, limit=1)
+    telemetry_records = load_training_records(run_dir, limit=1) if include_telemetry else []
     telemetry = telemetry_records[-1] if telemetry_records else None
     manifest = load_json(run_dir / "training_manifest.json")
     status = load_json(run_dir / "run_status.json") or {}
     log_path = training_log_path(run_dir, root)
-    errors = error_excerpt(log_path)
+    errors = error_excerpt(log_path) if include_errors else []
 
     state = status.get("state")
     if not state:
@@ -314,7 +407,9 @@ def summarize_run(run_dir: Path, root: Path, now: float | None = None) -> dict[s
             state = "error"
         elif telemetry and now - run_modified_time(run_dir) < 30:
             state = "running"
-        elif telemetry or (run_dir / "params" / "agent.yaml").is_file():
+        elif telemetry or (run_dir / "params" / "agent.yaml").is_file() or next(
+            run_dir.glob("model_*.pt"), None
+        ) is not None:
             state = "finished"
         else:
             state = "unknown"
@@ -333,10 +428,10 @@ def summarize_run(run_dir: Path, root: Path, now: float | None = None) -> dict[s
         "status": status,
         "telemetry": telemetry,
         "errors": errors,
-        "latest_render": latest_render(run_dir),
+        "latest_render": latest_render(run_dir) if include_artifacts else None,
         "has_log": log_path.is_file(),
-        "has_checkpoint": (run_dir / "checkpoint").is_dir()
-        or bool(list(run_dir.glob("model_*.pt"))),
+        "has_checkpoint": include_artifacts
+        and ((run_dir / "checkpoint").is_dir() or next(run_dir.glob("model_*.pt"), None) is not None),
     }
 
 

--- a/tests_dashboard/test_monitor.py
+++ b/tests_dashboard/test_monitor.py
@@ -1,17 +1,16 @@
 import json
 import os
 
-from dashboard.monitor import tail_lines
-from dashboard.monitor import load_log_records
 from dashboard.health import (
     _pid_namespace,
     decorate_records,
     discover_dashboard_runs,
-    load_dashboard_records,
     list_dashboard_summaries,
+    load_dashboard_records,
     process_status,
     summarize_dashboard_run,
 )
+from dashboard.monitor import load_log_records, tail_lines
 
 
 def test_tail_lines_reads_the_requested_suffix_without_changing_line_shape(tmp_path):

--- a/tests_dashboard/test_monitor.py
+++ b/tests_dashboard/test_monitor.py
@@ -1,14 +1,70 @@
 import json
 import os
 
+from dashboard.monitor import tail_lines
+from dashboard.monitor import load_log_records
 from dashboard.health import (
     _pid_namespace,
     decorate_records,
     discover_dashboard_runs,
     load_dashboard_records,
+    list_dashboard_summaries,
     process_status,
     summarize_dashboard_run,
 )
+
+
+def test_tail_lines_reads_the_requested_suffix_without_changing_line_shape(tmp_path):
+    log = tmp_path / "training.log"
+    log.write_text("first\nsecond\nthird\nfourth", encoding="utf-8")
+
+    assert tail_lines(log, 2) == ["third\n", "fourth"]
+
+
+def test_log_records_supply_recent_rsl_rl_metrics_without_tensorboard(tmp_path):
+    log = tmp_path / "training.log"
+    log.write_text(
+        "\x1b[1m Learning iteration 41/100 \x1b[0m\n"
+        "Total steps: 503808\n"
+        "Steps per second: 12345\n"
+        "Mean surrogate loss: -0.0125\n"
+        "Mean reward: 18.25\n"
+        "Mean episode length: 75.5\n",
+        encoding="utf-8",
+    )
+
+    records = load_log_records(tmp_path)
+
+    assert records == [
+        {
+            "completed_steps": 41,
+            "total_steps": 100,
+            "metrics": {
+                "total_environment_steps": 503808.0,
+                "Perf/total_fps": 12345.0,
+                "Loss/surrogate": -0.0125,
+                "Train/mean_reward": 18.25,
+                "Train/mean_episode_length": 75.5,
+            },
+        }
+    ]
+
+
+def test_run_list_defers_tensorboard_loading_until_a_run_is_selected(monkeypatch, tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run_status.json").write_text('{"state": "finished"}', encoding="utf-8")
+    (run_dir / "events.out.tfevents.synthetic").write_bytes(b"not-read-by-the-list")
+
+    monkeypatch.setattr(
+        "dashboard.health.load_dashboard_records",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected telemetry read")),
+    )
+
+    summaries = list_dashboard_summaries(tmp_path)
+
+    assert len(summaries) == 1
+    assert summaries[0]["telemetry"] is None
 
 
 def test_canonical_metrics_and_non_finite_detection(tmp_path):


### PR DESCRIPTION
## Summary
- avoid whole-log and TensorBoard rescans during routine dashboard refreshes
- make polling non-overlapping and less frequent, while batching console updates
- cache artifact discovery and avoid checkpoint enumeration in the run library
- fix the Ruff import-order failure that caused Dashboard CI to stop before the dashboard tests ran

## Validation
- Dashboard CI run #211: passed
- dashboard backend tests: passed
- Ruff: passed
- frontend clean install + production build: passed
- backend mjlab tests: passed
- maintenance/Docker configuration checks: passed