### PR TITLE
Improve dashboard responsiveness

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 import time
 
 from fastapi import FastAPI, HTTPException, Request
@@ -34,6 +35,12 @@ ARTIFACT_ROOT = CONFIG.artifact_root
 FRONTEND_DIST = CONFIG.frontend_dist
 RUN_SERVICE = RunService(ARTIFACT_ROOT, stale_after_seconds=CONFIG.stale_after_seconds)
 SUPERVISOR = SupervisorClient()
+
+# Artifact discovery walks a mounted training directory.  Keeping the annotated
+# list briefly avoids making every UI poll repeat that full filesystem scan.
+_SUMMARY_CACHE_TTL_S = 25.0
+_SUMMARY_CACHE_LOCK = threading.Lock()
+_SUMMARY_CACHE: tuple[float, list[dict]] | None = None
 
 app = FastAPI(title="Ascento Training Monitor", version="2.1")
 
@@ -98,7 +105,32 @@ def _artifact_health() -> list[str]:
     return problems
 
 
+def _invalidate_summary_cache() -> None:
+    global _SUMMARY_CACHE
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE = None
+
+
+def _cached_summary_count() -> int | None:
+    with _SUMMARY_CACHE_LOCK:
+        if _SUMMARY_CACHE is None:
+            return None
+        cached_at, summaries = _SUMMARY_CACHE
+        if time.monotonic() - cached_at >= _SUMMARY_CACHE_TTL_S:
+            return None
+        return len(summaries)
+
+
 def _annotated_summaries() -> list[dict]:
+    global _SUMMARY_CACHE
+    with _SUMMARY_CACHE_LOCK:
+        if _SUMMARY_CACHE is not None:
+            cached_at, summaries = _SUMMARY_CACHE
+            if time.monotonic() - cached_at < _SUMMARY_CACHE_TTL_S:
+                return list(summaries)
+
+    # Keep the lock out of the filesystem walk so a health request is never
+    # held behind a slow network or mounted-drive scan.
     summaries = list_dashboard_summaries(
         ARTIFACT_ROOT,
         stale_after_seconds=CONFIG.stale_after_seconds,
@@ -108,17 +140,20 @@ def _annotated_summaries() -> list[dict]:
         ref = refs.get(summary.get("id"))
         if ref is not None:
             RUN_SERVICE.annotate(summary, ref.path)
-    return summaries
+
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE = (time.monotonic(), summaries)
+    return list(summaries)
 
 
 @app.get("/api/health")
 def health():
     problems = _artifact_health()
-    try:
-        run_count = len(_annotated_summaries())
-    except OSError as error:
-        problems.append(f"artifact scan failed: {error}")
-        run_count = None
+    # Health is polled alongside /api/runs.  Do not make it perform a second
+    # full artifact traversal just to produce an informational count.
+    run_count = _cached_summary_count()
+    if run_count is None and not ARTIFACT_ROOT.exists():
+        run_count = 0
     return {
         "ok": not problems,
         "status": "ok" if not problems else "error",
@@ -190,7 +225,9 @@ def runs():
 @app.post("/api/runs", status_code=202)
 def create_run(request: RunCreateRequest):
     try:
-        return RUN_SERVICE.create(request.model_dump())
+        created = RUN_SERVICE.create(request.model_dump())
+        _invalidate_summary_cache()
+        return created
     except KeyError as error:
         raise HTTPException(
             status_code=400, detail=f"parent run not found: {error.args[0]}"
@@ -223,7 +260,9 @@ def run_status(run_id: str):
 @app.patch("/api/runs/{run_id}")
 def update_run(run_id: str, request: RunUpdateRequest):
     try:
-        return RUN_SERVICE.update_metadata(run_id, request.model_dump(exclude_unset=True))
+        updated = RUN_SERVICE.update_metadata(run_id, request.model_dump(exclude_unset=True))
+        _invalidate_summary_cache()
+        return updated
     except KeyError as error:
         raise HTTPException(
             status_code=404, detail="training run or parent run not found"
@@ -235,7 +274,9 @@ def update_run(run_id: str, request: RunUpdateRequest):
 @app.post("/api/runs/{run_id}/stop", status_code=202)
 def stop_run(run_id: str, request: RunStopRequest):
     try:
-        return RUN_SERVICE.stop(run_id, reason=request.reason.strip() or "user_requested")
+        stopped = RUN_SERVICE.stop(run_id, reason=request.reason.strip() or "user_requested")
+        _invalidate_summary_cache()
+        return stopped
     except KeyError as error:
         raise HTTPException(status_code=404, detail="training run not found") from error
     except ProcessLookupError as error:

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -10,7 +10,9 @@ import {
 } from 'recharts'
 
 const POLL_MS = 15000
-const CHART_RENDER_POINTS = 1200
+// Six SVG charts redraw together.  This cap keeps interactions responsive
+// while even sampling retains the full oldest-to-newest history span.
+const CHART_RENDER_POINTS = 400
 const LOG_TAIL_LIMIT = 400
 const LOG_DISPLAY_LIMIT = 600
 const LOG_FLUSH_MS = 500
@@ -267,6 +269,9 @@ function App() {
     }
   }
 
+  const selectedRunState = runs.find((run) => run.id === selectedId)?.state
+  const selectedRunIsLive = ['starting', 'running', 'stopping'].includes(selectedRunState)
+
   useEffect(() => {
     refreshHealth()
     refreshRuns()
@@ -284,9 +289,12 @@ function App() {
     }
     setCopyState('')
     refreshSelected(selectedId)
+    // Archived runs have immutable telemetry. Re-reading their logs every
+    // poll is expensive on a mounted workspace without yielding newer data.
+    if (!selectedRunIsLive) return undefined
     const timer = setInterval(() => refreshSelected(selectedId), POLL_MS)
     return () => clearInterval(timer)
-  }, [selectedId])
+  }, [selectedId, selectedRunIsLive])
 
   useEffect(() => {
     if (!selectedId) return undefined

--- a/tests_dashboard/test_backend.py
+++ b/tests_dashboard/test_backend.py
@@ -40,6 +40,20 @@ def test_dashboard_starts_before_read_only_artifact_root_exists(monkeypatch, tmp
     assert module.runs() == {"runs": []}
 
 
+def test_health_does_not_trigger_an_expensive_run_summary_scan(monkeypatch, tmp_path):
+    module = _load_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        module,
+        "_annotated_summaries",
+        lambda: (_ for _ in ()).throw(AssertionError("health should not scan runs")),
+    )
+
+    health = module.health()
+
+    assert health["ok"] is True
+    assert health["run_count"] is None
+
+
 def test_run_summary_download_is_json_safe(monkeypatch, tmp_path):
     module = _load_app(monkeypatch, tmp_path)
     run_dir = tmp_path / "run"


### PR DESCRIPTION
## Summary
- avoid expensive artifact scans from the health polling path
- cache annotated run summaries and invalidate after run lifecycle changes
- cap full-history chart rendering at 400 evenly sampled points
- stop polling immutable archived-run telemetry

## Validation
- 48 dashboard tests passed
- ruff check passed
- live dashboard polling verified